### PR TITLE
Try building latest OpenBLAS release: v0.3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
     global:
         # The archive that gets built has name from ``git describe`` on this
         # commit.
-        - BUILD_COMMIT=701ea88
+        - BUILD_COMMIT=v0.3.5
         - REPO_DIR=OpenBLAS
         - PLAT=x86_64
         - WHEELHOUSE_UPLOADER_USERNAME=travis-worker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ os: Visual Studio 2015
 
 environment:
   global:
-    OPENBLAS_COMMIT: 701ea88
+    OPENBLAS_COMMIT: v0.3.5
     OPENBLAS_ROOT: c:\opt
     MSYS2_ROOT: c:\msys64
     WHEELHOUSE_UPLOADER_USERNAME: travis-worker


### PR DESCRIPTION
Related to discussion in: https://github.com/numpy/numpy/issues/13173

cc @matthew-brett & @charris 

Looks like I can just use the version tag for building at the exact release point based on project history. This should bump the version built from `v0.3.5.dev` (at a specific development hash) to `v0.3.5` proper.

I note that there are no badges / links in the `openblas-libs` README for monitoring the CI builds of OpenBLAS, which might be useful to have?