### PR TITLE
BLD: use latest OpenBLAS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
     global:
         # The archive that gets built has name from ``git describe`` on this
         # commit.
-        - BUILD_COMMIT=v0.3.5
+        - BUILD_COMMIT=3f427c0cf9
         - REPO_DIR=OpenBLAS
         - PLAT=x86_64
         - WHEELHOUSE_UPLOADER_USERNAME=travis-worker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ os: Visual Studio 2015
 
 environment:
   global:
-    OPENBLAS_COMMIT: v0.3.5
+    OPENBLAS_COMMIT: 3f427c0cf9
     OPENBLAS_ROOT: c:\opt
     MSYS2_ROOT: c:\msys64
     WHEELHOUSE_UPLOADER_USERNAME: travis-worker


### PR DESCRIPTION
Build the latest stable release of `OpenBLAS`, `v0.3.6`, as requested by @charris based on evidence of Skylake-related issues reported downstream in NumPy, thanks to some debugging help from @matthew-brett: 

- https://github.com/numpy/numpy/issues/13426#issuecomment-487728632
- https://github.com/numpy/numpy/issues/13401#issuecomment-487763291

The [`v0.3.6` release notes](https://github.com/xianyi/OpenBLAS/releases/tag/v0.3.6) explicitly mention:

> fixed building on SkylakeX systems when either the compiler or the (emulated) operating 
  environment does not support AVX512

@rgommers we may also want to consider bumping OpenBLAS for upcoming SciPy release if we think the tradeoff for changing versions from the rc to the final release is worth it for this possible issue?