### PR TITLE
BLD: bump OpenBLAS for SkylakeX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
     global:
         # The archive that gets built has name from ``git describe`` on this
         # commit.
-        - BUILD_COMMIT=3f427c0cf9
+        - BUILD_COMMIT=6a8b426
         - REPO_DIR=OpenBLAS
         - PLAT=x86_64
         - WHEELHOUSE_UPLOADER_USERNAME=travis-worker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ os: Visual Studio 2015
 
 environment:
   global:
-    OPENBLAS_COMMIT: 3f427c0cf9
+    OPENBLAS_COMMIT: 6a8b426
     OPENBLAS_ROOT: c:\opt
     MSYS2_ROOT: c:\msys64
     WHEELHOUSE_UPLOADER_USERNAME: travis-worker


### PR DESCRIPTION
* bump version of OpenBLAS used to most
recent commit on 0.3.7.dev branch, as it
will contain more fixes related to SkylakeX
kernel affecting NumPy linalg tests

In particular, we have an interest in https://github.com/xianyi/OpenBLAS/pull/2111
which specifically mentions the NumPy problem & was merged even more recently.

If this builds successfully, I'll want to try bumping OpenBLAS again in https://github.com/numpy/numpy/pull/13466
which contains Intel SDE emulation for SkylakeX issue with NumPy, to check for resolution.

Obviously, we'd like to automate this process a little more re: cross-project testing, but for now at least we have some reproducers / a CI model to verify.