### PR TITLE
BLD: bump OpenBLAS to 0.3.7 stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
     global:
         # The archive that gets built has name from ``git describe`` on this
         # commit.
-        - BUILD_COMMIT=6a8b426
+        - BUILD_COMMIT=v0.3.7
         - REPO_DIR=OpenBLAS
         - PLAT=x86_64
         - WHEELHOUSE_UPLOADER_USERNAME=travis-worker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ os: Visual Studio 2015
 
 environment:
   global:
-    OPENBLAS_COMMIT: 6a8b426
+    OPENBLAS_COMMIT: v0.3.7
     OPENBLAS_ROOT: c:\opt
     MSYS2_ROOT: c:\msys64
     WHEELHOUSE_UPLOADER_USERNAME: travis-worker


### PR DESCRIPTION
* the stable release of OpenBLAS `0.3.7`
is now available so produce the binary
for ecosystem wheels

The problematic SkylakeX AVX512 kernels are still disabled, but there are some performance improvements elsewhere.