### PR TITLE
MAINT: bump OpenBLAS to 0.3.8.dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
     global:
         # The archive that gets built has name from ``git describe`` on this
         # commit.
-        - BUILD_COMMIT=v0.3.7
+        - BUILD_COMMIT=c815b8f
         - REPO_DIR=OpenBLAS
         - PLAT=x86_64
         - WHEELHOUSE_UPLOADER_USERNAME=travis-worker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ os: Visual Studio 2015
 
 environment:
   global:
-    OPENBLAS_COMMIT: v0.3.7
+    OPENBLAS_COMMIT: c815b8f
     OPENBLAS_ROOT: c:\opt
     MSYS2_ROOT: c:\msys64
     WHEELHOUSE_UPLOADER_USERNAME: travis-worker


### PR DESCRIPTION
* AVX512 DGEMM kernel was rewritten
and reactivated with reasonable match
to MKL performance

* SGEMM, CGEMM, ZGEMM were adjusted
for better match to MKL performance

* there were some upstream questions
about develop branch working with NumPy,
so maybe doesn't hurt to make the binary
available in our ecosystem now; bigger
changes may be looming with new LAPACK
release recently, but OpenBLAS needs its
shims adjusted for that to be leveraged in