### PR TITLE
MAINT: build v0.3.7 binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
     global:
         # The archive that gets built has name from ``git describe`` on this
         # commit.
-        - BUILD_COMMIT=c815b8f
+        - BUILD_COMMIT=v0.3.7
         - REPO_DIR=OpenBLAS
         - PLAT=x86_64
         - WHEELHOUSE_UPLOADER_USERNAME=travis-worker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ os: Visual Studio 2015
 
 environment:
   global:
-    OPENBLAS_COMMIT: c815b8f
+    OPENBLAS_COMMIT: v0.3.7
     OPENBLAS_ROOT: c:\opt
     MSYS2_ROOT: c:\msys64
     WHEELHOUSE_UPLOADER_USERNAME: travis-worker


### PR DESCRIPTION
Do not merge!

* rebuild openblas-libs binaries for OpenBLAS v0.3.7
to provide this version for the 64-bit integer symbol-suffixed
builds recently added (which are otherwise currently only
available with a development commit on the path to v0.3.8)

I think because this feature branch originates in the repo proper as opposed to a fork, it should upload the new binaries to the usual rackspace location if CI passes.

I could be wrong though @pv, let me know if they don't get uploaded there after CI..

If this works, let's just close down this PR after the uploads.
