### PR TITLE
Fix openblas msvc export library generation

### DIFF
--- a/appveyor/build_gfortran.sh
+++ b/appveyor/build_gfortran.sh
@@ -1,4 +1,7 @@
 # Build gfortran binary against OpenBLAS
+
+set -e
+
 cd $(cygpath "$START_DIR")
 OBP=$(cygpath $OPENBLAS_ROOT\\$BUILD_BITS)
 

--- a/appveyor/build_openblas.sh
+++ b/appveyor/build_openblas.sh
@@ -6,6 +6,8 @@
 #  BUILD_BITS
 #  VC9_ROOT
 
+set -e
+
 # Paths in Unix format
 OPENBLAS_ROOT=$(cygpath "$OPENBLAS_ROOT")
 VC9_ROOT=$(cygpath "$VC9_ROOT")

--- a/appveyor/build_openblas.sh
+++ b/appveyor/build_openblas.sh
@@ -90,11 +90,7 @@ cd $BUILD_BITS/lib
 # At least for the mingwpy wheel, we have to use the VC tools to build the
 # export library. Maybe fixed in later binutils by patch referred to in
 # https://sourceware.org/ml/binutils/2016-02/msg00002.html
-if [ "$INTERFACE64" == "1" ]; then
-    cp ${our_wd}/OpenBLAS/exports/${DLL_BASENAME}.def ${DLL_BASENAME}.def
-else
-    cp ${our_wd}/OpenBLAS/exports/libopenblas.def ${DLL_BASENAME}.def
-fi
+cp ${our_wd}/OpenBLAS/exports/${DLL_BASENAME}.def ${DLL_BASENAME}.def
 "$VC9_ROOT/bin/lib.exe" /machine:${vc_arch} /def:${DLL_BASENAME}.def
 cd ../..
 # Build template site.cfg for using this build


### PR DESCRIPTION
The command building .lib export library on MSVC seems to be currently failing.

This does not seem to be new, see e.g.  https://ci.appveyor.com/project/matthew-brett/openblas-libs/builds/26629867/job/2i2y96hhfgwlpjb3 from some months ago, where there is "LINK : fatal error LNK1104: cannot open file 'libopenblas_v0.3.7-gcc_7_1_0.def'" close to the end, and the generated .zip artifact is missing the msvc .lib and .def files.

It was fixed that for the INTERFACE64=1 case in #8, but I left the other case alone assuming it was different for some reason --- but it seems it has been broken. Numpy et al. don't need these files for building (due to the way numpy.distutils handles gfortran compatibility), so it's not particularly urgent.

Also, add `set -e ` flag to the bash build scripts, so that failures like this become fatal.