### PR TITLE
MAINT: disable rackspace uploads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,9 @@ script:
 after_success:
     # Upload libraries to Rackspace container
     - pip install wheelhouse-uploader
-    - python -m wheelhouse_uploader upload --local-folder
-          ${TRAVIS_BUILD_DIR}/libs/
-          --no-update-index
-          wheels
+    # Now disabled because we have lost free
+    # services with Rackspace
+    #- python -m wheelhouse_uploader upload --local-folder
+    #     ${TRAVIS_BUILD_DIR}/libs/
+    #     --no-update-index
+    #     wheels

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,9 @@ on_success:
   # disable the ssl checks.
   - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
   - pip install wheelhouse-uploader
-  - python -m wheelhouse_uploader upload
-    --no-ssl-check --local-folder=builds
-    --no-update-index
-    wheels
+  # Now disabled because we have lost free
+  # services with Rackspace
+  #- python -m wheelhouse_uploader upload
+  # --no-ssl-check --local-folder=builds
+  # --no-update-index
+  # wheels


### PR DESCRIPTION
* the community has apparently lost free services
with rackspace hosting: https://mail.python.org/pipermail/scipy-dev/2020-February/023990.html

* as a first step torward migration, and to prevent undesired
charges, disable rackspace uploads of our OpenBLAS build
artifacts from CI

cc @matthew-brett @mattip @ogrisel

I beleive @aterrel noted that there was an extenion, but Olivier has no confirmation for the specific container we are using, and Andy wanted the migration to happen sooner than later anyway given recent events.

Once disabled, we can start to experiment with alternative solutions.