### PR TITLE
Anaconda upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,10 +98,4 @@ after_success:
     # Note that the anaconda-client package on PyPI is too old. Install from github
     # tag instead:
     - pip install -q git+https://github.com/Anaconda-Platform/anaconda-client@1.7.2
-    - anaconda -t $OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN upload
-            --no-progress --force -u multibuild-wheels-staging
-            -t file -p "openblas-libs"
-            -v "$(cd OpenBLAS && git describe --tags)"
-            -d "OpenBLAS for multibuild wheels"
-            -s "OpenBLAS for multibuild wheels"
-            libs/openblas*.tar.gz
+    - upload_to_anaconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,8 @@ after_success:
     - pip install -q git+https://github.com/Anaconda-Platform/anaconda-client@1.7.2
     - anaconda -t $OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN upload
             --no-progress --force -u multibuild-wheels-staging
-            -t file -p "openblas" -v "$(cd OpenBLAS && git describe --tags)"
+            -t file -p "openblas-libs"
+            -v "$(cd OpenBLAS && git describe --tags)"
             -d "OpenBLAS for multibuild wheels"
             -s "OpenBLAS for multibuild wheels"
             libs/openblas*.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,14 @@ env:
         # commit.
         - BUILD_COMMIT=c815b8f
         - REPO_DIR=OpenBLAS
-        - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
-        # Following generated with
-        # travis encrypt -r MacPython/openblas-libs WHEELHOUSE_UPLOADER_SECRET=<the api key>
-        - secure: "NRSuGmMTcNSbpQwiXWS4o2dKQr9bXgDEHD3D6SjDdEe44rsLMDRt8xaUoFIcvfI7zalazn5k545RsxOECeXG2k0xJGIAGtJFlianq9Fk+6ICQZdCGS46EEp95zzjYhWc8GQWAdqFVxJ/j6hPP2NXlvjQgvMKQi0hkM/dlc7f2YOYt9JNin8K2m0v/bE3l8JtF3T/VUGYKMhpLquFVRdZP16MUgNc9K0eiGtOqz2HLctez/b3PoHa2VjqyilgUAMFGQRZdlhd+GIC4TNBxiYlbCgiY81sehkM4TXIQrLVJqNeafM1qRtVLssCT4A3mZcmS3QiwMFuhwD6mDKw60brYOWGlcOZ8W4wm8qx3XXDxHfkVengiAZEvTlimTfx2k4gYrRYvXawTmAsSBFZmQom1rfx0IUC9Nfd9q3E08ZWcjaMkqr3hLdVnSr/2j+8D6yJQuuxj6NrCv2EXB5cEPgM9Cya3cLjBO7QzI9hjWsgRBSg2UcDr8Cy/apxIvnJWftLUs5BUv1BvczDxZ8OqiDYUh2LkJBzLG1Z4/ZHxovvWcDy9VKR681cxjBIde2CY2vMYhYyuVcoeQimsinxzFP+N6DyHEsEb/jYGBPkQTUnqh1PtgHouvOSSw8RDoq6JLjSdhEnZ1cHeQ1CTPzjld/Y6QIecLRcCsYif6ZNdCv3rik="
+        # Following generated with:
+        # travis encrypt -r MacPython/openblas-libs OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN=<secret token value>
+        # The value of the existing token can be retrieved at the bottom of the page at:
+        #   https://anaconda.org/multibuild-wheels-staging/settings/access:
+        # To generate a new token, we need the permissions:
+        # - "Allow write access to the API site"
+        # - "Allow uploads to PyPI repositories"
+        - secure: "vxMRXsnSBczv/u4HF0LT2U/f5wdTosSWmORwcNv8A/46uFK5CExbVj/LqW0e4fnrv2EZX2sDokrC/3nZAvlxRiZSkJ6dR34lU7ysPheD1sTdpVnKFrajcu22gmMmrORQf/v0ntkFYQj/+zRqVGb8QJLxW9bj8mEoWH4vkmnIHyRNuuIeLQrlbU3PeXusQ1/XoCrmlsU9kg8pyTwzfpG00T7BkACbZBYhRK84LCB4pIYgxxWgMKXH8DSqVxsK9egYXZM58YQwIOJGwpqw5XyYH+aKjZqSz1opNbzClWwT3hgAveVgQ7t2rZ8YZ0I6GyphLQ9JId/Vmuza0TjwzlCcexNSsAfolbqiCcwBElNBDpUzNB4bRzyGc3vckE/C+PlDoRL1be0UHoEnyzmIzwhwVrZKOyz7pGkbdtjOoqB5VgoMy04Tnd2l4mkJkx5ub3v7Z0Q74LWKKaZJcXBVIATIjZu43jI9Y9HYV8Ey0CcZY33EjwpOe7wSVgiSDcTv1KUS1tJwZpHX+duJSYMQyWRhkTxKtt8E1FosNQ1fRZMFmY74mAdVPIv9Vn1qgSnOCSkNGlLBIjVCozie0HVlzUk1FhvLtral3b/hp7+6JVjU1sp7HnaS/DtHTq57kceEbT56GxbQopye1zvecnhUp9tohLFeSzk/zJcvXGTIMrJlWnU="
         # > 10.6 needed for OpenBLAS 0.3.1 to avoid thread-local storage error
         # in memory.c
         - MACOSX_DEPLOYMENT_TARGET=10.9
@@ -90,11 +94,13 @@ script:
     - build_lib "$PLAT" "$INTERFACE64"
 
 after_success:
-    # Upload libraries to Rackspace container
-    - pip install wheelhouse-uploader
-    # Now disabled because we have lost free
-    # services with Rackspace
-    #- python -m wheelhouse_uploader upload --local-folder
-    #     ${TRAVIS_BUILD_DIR}/libs/
-    #     --no-update-index
-    #     wheels
+    # Upload libraries to the shared staging area on anaconda.org
+    # Note that the anaconda-client package on PyPI is too old. Install from github
+    # tag instead:
+    - pip install -q git+https://github.com/Anaconda-Platform/anaconda-client@1.7.2
+    - anaconda -t $OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN upload
+            --no-progress --force -u multibuild-wheels-staging
+            -t file -p "openblas" -v "$(cd OpenBLAS && git describe --tags)"
+            -d "OpenBLAS for multibuild wheels"
+            -s "OpenBLAS for multibuild wheels"
+            libs/openblas*.tar.gz

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,14 @@ environment:
     OPENBLAS_COMMIT: c815b8f
     OPENBLAS_ROOT: c:\opt
     MSYS2_ROOT: c:\msys64
-    WHEELHOUSE_UPLOADER_USERNAME: travis-worker
-    WHEELHOUSE_UPLOADER_SECRET:
-      secure: 9s0gdDGnNnTt7hvyNpn0/ZzOMGPdwPp2SewFTfGzYk7uI+rdAN9rFq2D1gAP4NQh
-    PYTHON: "C:\\Python27"
+    # The value of the existing token can be retrieved at the bottom of the page at:
+    #   https://anaconda.org/multibuild-wheels-staging/settings/access:
+    # To generate a new token, we need the permissions:
+    # - "Allow write access to the API site"
+    # - "Allow uploads to PyPI repositories"
+    OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN:
+      secure: k5Mel0+U/e+KIdJCwtQzuGuekEdCuGTRcoE5fRzFOwvqcqnwUOOtgpQ8wTZFvuXr
+    PYTHON: "C:\\Python37"
 
   # Need for mingw-builds discussed at
   # https://github.com/xianyi/OpenBLAS/issues/1503
@@ -60,14 +64,9 @@ on_finish:
   - ps: Get-ChildItem builds\*.* | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 
 on_success:
-  # Upload the generated package to Rackspace
-  # On Windows, Apache Libcloud cannot find a standard CA cert bundle so we
-  # disable the ssl checks.
+  # Upload libraries to the shared staging area on anaconda.org
+  # Note that the anaconda-client package on PyPI is too old. Install from github
+  # tag instead:
   - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
-  - pip install wheelhouse-uploader
-  # Now disabled because we have lost free
-  # services with Rackspace
-  #- python -m wheelhouse_uploader upload
-  # --no-ssl-check --local-folder=builds
-  # --no-update-index
-  # wheels
+  - pip install -q git+https://github.com/Anaconda-Platform/anaconda-client@1.7.2
+  - bash --login %SCRIPT_DIR%upload_to_anaconda_staging.sh

--- a/appveyor/upload_to_anaconda_staging.sh
+++ b/appveyor/upload_to_anaconda_staging.sh
@@ -9,12 +9,16 @@ pushd OpenBLAS
 VERSION=$(git describe --tags)
 popd
 
-echo "Uploading OpenBLAS $VERSION to anaconda.org staging:"
-ls -lh builds/openblas*.zip
+if [ "$OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN" == "" ]; then
+    echo "OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN is not defined: skipping."
+else
+    echo "Uploading OpenBLAS $VERSION to anaconda.org staging:"
+    ls -lh builds/openblas*.zip
 
-anaconda -t $OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN upload \
-          --no-progress --force -u multibuild-wheels-staging \
-          -t file -p "openblas-libs" -v "$VERSION" \
-          -d "OpenBLAS for multibuild wheels" \
-          -s "OpenBLAS for multibuild wheels" \
-          builds/openblas*.zip
+    anaconda -t $OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN upload \
+            --no-progress --force -u multibuild-wheels-staging \
+            -t file -p "openblas-libs" -v "$VERSION" \
+            -d "OpenBLAS for multibuild wheels" \
+            -s "OpenBLAS for multibuild wheels" \
+            builds/openblas*.zip
+fi

--- a/appveyor/upload_to_anaconda_staging.sh
+++ b/appveyor/upload_to_anaconda_staging.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Build script for OpenBLAS on Windows
+set -e
+
+our_wd=$(cygpath "$START_DIR")
+cd $our_wd
+
+pushd OpenBLAS
+VERSION=$(git describe --tags)
+popd
+
+echo "Uploading OpenBLAS $VERSION to anaconda.org staging:"
+ls -lh builds/openblas*.zip
+
+anaconda -t $OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN upload \
+          --no-progress --force -u multibuild-wheels-staging \
+          -t file -p "openblas" -v "$VERSION" \
+          -d "OpenBLAS for multibuild wheels" \
+          -s "OpenBLAS for multibuild wheels" \
+          builds/openblas*.zip

--- a/appveyor/upload_to_anaconda_staging.sh
+++ b/appveyor/upload_to_anaconda_staging.sh
@@ -14,7 +14,7 @@ ls -lh builds/openblas*.zip
 
 anaconda -t $OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN upload \
           --no-progress --force -u multibuild-wheels-staging \
-          -t file -p "openblas" -v "$VERSION" \
+          -t file -p "openblas-libs" -v "$VERSION" \
           -d "OpenBLAS for multibuild wheels" \
           -s "OpenBLAS for multibuild wheels" \
           builds/openblas*.zip

--- a/travis-ci/build_steps.sh
+++ b/travis-ci/build_steps.sh
@@ -134,3 +134,17 @@ function do_build_lib {
         $BUILD_PREFIX/lib/libopenblas* \
         $BUILD_PREFIX/lib/cmake/openblas
 }
+
+function upload_to_anaconda {
+    if [ "$OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN" == "" ]; then
+        echo "OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN is not defined: skipping."
+    else
+        anaconda -t $OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN upload \
+            --no-progress --force -u multibuild-wheels-staging \
+            -t file -p "openblas-libs" \
+            -v "$(cd OpenBLAS && git describe --tags)" \
+            -d "OpenBLAS for multibuild wheels" \
+            -s "OpenBLAS for multibuild wheels" \
+            libs/openblas*.tar.gz
+    fi
+}


### PR DESCRIPTION
Use the shared staging area as openblas builds are useful for several projects.

I am not sure if the encrypted value for the token in the appveyor configuration will work. Maybe it will need to be re-encrypted by someone logged in with the MacPython github account on appveyor. It's very clear to me.


Potential fix for #14.