### PR TITLE
MAINT: encrypt upload token directly in Appveyor UI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,8 @@ environment:
     # To generate a new token, we need the permissions:
     # - "Allow write access to the API site"
     # - "Allow uploads to PyPI repositories"
-    OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN:
-      secure: CMOhqPqFG0CdbfKNhKW4IAVPRNiTU2QFxHazcIEG+OR3SR7tBL1/fIvpXiRar5Xj
+    # OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN: this variable has been encrypted
+    # in the appveyor UI at: https://ci.appveyor.com/project/tylerjereddy/openblas-libs/settings/environment
     PYTHON: "C:\\Python37"
 
   # Need for mingw-builds discussed at


### PR DESCRIPTION
* attempt to encrypt the OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN
as a project "collaborator" & then open PR from a feature
branch within the repo proper, to see if this allows
accessing the secure token in Appveyor