### PR TITLE
add manylinux2010 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,20 @@ matrix:
         - PLAT=ppc64le
         - INTERFACE64=1
         - MB_ML_VER=2014
+    # linux manylinux2010
+    - os: linux
+      env:
+        - PLAT=x86_64
+        - MB_ML_VER=2010
+    - os: linux
+      env:
+        - PLAT=i686
+        - MB_ML_VER=2010
+    - os: linux
+      env:
+        - PLAT=x86_64
+        - INTERFACE64=1
+        - MB_ML_VER=2010
 
 before_install:
     - source travis-ci/build_steps.sh


### PR DESCRIPTION
add manylinux 2010 builds for linux. There are three new entries. This is meant to try to address the segfaults on i686 in MacPython/numpy-wheels#73