### PR TITLE
MAINT: bump to OpenBLAS v0.3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
     global:
         # The archive that gets built has name from ``git describe`` on this
         # commit.
-        - BUILD_COMMIT=ddcbed6  # xianyi/OpenBLAS#2445 recommends this until 0.3.9 is released
+        - BUILD_COMMIT=v0.3.9
         - REPO_DIR=OpenBLAS
         # Following generated with:
         # travis encrypt -r MacPython/openblas-libs OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN=<secret token value>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ os: Visual Studio 2015
 
 environment:
   global:
-    OPENBLAS_COMMIT: ddcbed6
+    OPENBLAS_COMMIT: v0.3.9
     OPENBLAS_ROOT: c:\opt
     MSYS2_ROOT: c:\msys64
     # The value of the existing token can be retrieved at the bottom of the page at:


### PR DESCRIPTION
Fixes #16 

* OpenBLAS v0.3.9 contains numerous important
bugfixes, and follows only ~2 weeks after v0.3.8,
so make this latest stable release available
to the ecosystem

`v0.3.9` was released about 20 minutes ago