### PR TITLE
MAINT: restore ARM64 64-bit int

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,13 +52,13 @@ matrix:
         - PLAT=aarch64
         - MB_ML_VER=2014
         - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
-    #- os: linux
-    #  arch: arm64
-    #  env:
-    #    - PLAT=aarch64
-    #    - INTERFACE64=1
-    #    - MB_ML_VER=2014
-    #    - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+    - os: linux
+      arch: arm64
+      env:
+        - PLAT=aarch64
+        - INTERFACE64=1
+        - MB_ML_VER=2014
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
     - os: linux
       arch: s390x
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
     global:
         # The archive that gets built has name from ``git describe`` on this
         # commit.
-        - BUILD_COMMIT=v0.3.9
+        - BUILD_COMMIT=b9a2a3c54
         - REPO_DIR=OpenBLAS
         # Following generated with:
         # travis encrypt -r MacPython/openblas-libs OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN=<secret token value>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ os: Visual Studio 2015
 
 environment:
   global:
-    OPENBLAS_COMMIT: v0.3.9
+    OPENBLAS_COMMIT: b9a2a3c54
     OPENBLAS_ROOT: c:\opt
     MSYS2_ROOT: c:\msys64
     # The value of the existing token can be retrieved at the bottom of the page at:


### PR DESCRIPTION
* restore `arm64` 64-bit integer OpenBLAS
build in Travis CI matrix now that we
are building OpenBLAS 0.3.9 stable

* if this Travis CI matrix entry continues
to segfault during the build of OpenBLAS
we should report it upstream