### PR TITLE
MAINT: bump to OpenBLAS v0.3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
     global:
         # The archive that gets built has name from ``git describe`` on this
         # commit.
-        - BUILD_COMMIT=b9a2a3c54
+        - BUILD_COMMIT=v0.3.10
         - REPO_DIR=OpenBLAS
         # Following generated with:
         # travis encrypt -r MacPython/openblas-libs OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN=<secret token value>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ os: Visual Studio 2015
 
 environment:
   global:
-    OPENBLAS_COMMIT: b9a2a3c54
+    OPENBLAS_COMMIT: v0.3.10
     OPENBLAS_ROOT: c:\opt
     MSYS2_ROOT: c:\msys64
     # The value of the existing token can be retrieved at the bottom of the page at:


### PR DESCRIPTION
* OpenBLAS `v0.3.10` was released a few hours ago
and is the latest stable release; bump the version
here to make it available for testing in downstream
projects

cc @mattip @charris