### PR TITLE
add manylinux2014 build targets for linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,21 @@ matrix:
         - INTERFACE64=1
         - MB_ML_VER=2010
 
+    # linux manylinux2014
+    - os: linux
+      env:
+        - PLAT=x86_64
+        - MB_ML_VER=2014
+    - os: linux
+      env:
+        - PLAT=i686
+        - MB_ML_VER=2014
+    - os: linux
+      env:
+        - PLAT=x86_64
+        - INTERFACE64=1
+        - MB_ML_VER=2014
+
 before_install:
     - source travis-ci/build_steps.sh
     - before_build


### PR DESCRIPTION
we have manylinux1, manylinux2010, but not manylinux2014 x86 tarballs.

xref matthew-brett/multibuild#355

At some point we could rename these to not use manylinux tags to save the triple builds.