### PR TITLE
Update OpenBLAS commit to af2b0d0

### DIFF
--- a/.github/workflows/multibuild.yml
+++ b/.github/workflows/multibuild.yml
@@ -31,7 +31,7 @@ jobs:
             INTERFACE64: '1'
     env:
       REPO_DIR: OpenBLAS
-      OPENBLAS_COMMIT: v0.3.13
+      OPENBLAS_COMMIT: af2b0d0
       MACOSX_DEPLOYMENT_TARGET: 10.9
       MB_PYTHON_VERSION: ${{ matrix.python-version }}
       TRAVIS_PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
     global:
         # The archive that gets built has name from ``git describe`` on this
         # commit.
-        - OPENBLAS_COMMIT=v0.3.13
+        - OPENBLAS_COMMIT=af2b0d0
         - REPO_DIR=OpenBLAS
         # Following generated with:
         # travis encrypt -r MacPython/openblas-libs OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN=<secret token value>


### PR DESCRIPTION
Use a version of OpenBLAS that passes BUFFERSIZE on to the makefiles. Part of the fix for numpy/numpy#18141