### PR TITLE
add universal 64bit builds for macOS

### DIFF
--- a/.github/workflows/multibuild.yml
+++ b/.github/workflows/multibuild.yml
@@ -23,6 +23,10 @@ jobs:
         include:
           - os: macos-latest
             PLAT: arm64
+            INTERFACE64: '1'
+            platform: [x64]
+          - os: macos-latest
+            PLAT: arm64
             INTERFACE64: ''
             platform: [x64]
         exclude:


### PR DESCRIPTION
Add 64 bit builds for universal (arm64) macOS, update multibuild