### PR TITLE
update travis base image to bionic (ubuntu 18.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 
 language: python
 sudo: required
-dist: xenial
+dist: bionic
 services: docker
 
 matrix:


### PR DESCRIPTION
xenial went EOL in April 2021. 