### PR TITLE
backport PR 80 to v0.3.20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
     branches: [ master ]
 
 env:
-  OPENBLAS_COMMIT: "bfd9c1b58cd3"
+  OPENBLAS_COMMIT: "v0.3.20"
   OPENBLAS_ROOT: "c:\\opt"
 
 jobs:

--- a/.github/workflows/multibuild.yml
+++ b/.github/workflows/multibuild.yml
@@ -52,7 +52,7 @@ jobs:
             INTERFACE64: '1'
     env:
       REPO_DIR: OpenBLAS
-      OPENBLAS_COMMIT: "bfd9c1b58cd3"
+      OPENBLAS_COMMIT: "v0.3.20"
       MACOSX_DEPLOYMENT_TARGET: 10.9
       MB_PYTHON_VERSION: ${{ matrix.python-version }}
       TRAVIS_PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
     global:
         # The archive that gets built has name from ``git describe`` on this
         # commit.
-        - OPENBLAS_COMMIT="bfd9c1b58cd3"
+        - OPENBLAS_COMMIT="v0.3.20"
         - REPO_DIR=OpenBLAS
         # Following generated with:
         # travis encrypt -r MacPython/openblas-libs OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN=<secret token value>


### PR DESCRIPTION
This will overwrite the https://anaconda.org/multibuild-wheels-staging/openblas-libs/files with the version including #80 to use `protected` with the posix builds.