### PR TITLE
Fix for CFLAGS

### DIFF
--- a/travis-ci/build_steps.sh
+++ b/travis-ci/build_steps.sh
@@ -133,8 +133,7 @@ function do_build_lib {
             ;;
         Darwin-arm64)
             local bitness=64
-            # https://github.com/xianyi/OpenBLAS/issues/3659
-            local target_flags="TARGET=VORTEX NO_EXPRECISION=1"
+            local target_flags="TARGET=VORTEX"
             ;;
         *-s390x)
             local bitness=64
@@ -164,7 +163,7 @@ function do_build_lib {
     git config --global --add safe.directory '*'
     (cd OpenBLAS \
     && patch_source \
-    && CFLAGS="-fvisibility=protected" make BUFFERSIZE=20 DYNAMIC_ARCH=1 USE_OPENMP=0 NUM_THREADS=64 BINARY=$bitness $interface64_flags $target_flags > /dev/null \
+    && CFLAGS="$CFLAGS -fvisibility=protected" make BUFFERSIZE=20 DYNAMIC_ARCH=1 USE_OPENMP=0 NUM_THREADS=64 BINARY=$bitness $interface64_flags $target_flags > /dev/null \
     && make PREFIX=$BUILD_PREFIX $interface64_flags install )
     stop_spinner
     local version=$(cd OpenBLAS && git describe --tags --abbrev=8)


### PR DESCRIPTION
The following line is wiping out the set `CFLAGS` for the cross-compile:

```
      && CFLAGS="-fvisibility=protected" make BUFFERSIZE=20 ...
```

https://github.com/MacPython/openblas-libs/runs/6817632611

Put the existing CFLAGS back.