### PR TITLE
Nightly linux builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,5 +82,6 @@ jobs:
         env:
          OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN: ${{ secrets.MULTIBUILD_WHEELS_STAGING_ACCESS }}
         run: |
-          conda install anaconda-client
+          # Pin urllib3<2 due to github.com/Anaconda-Platform/anaconda-client/issues/654
+          conda install "urllib3<2" anaconda-client
           & $env:BASH_PATH -lc tools/upload_to_anaconda_staging.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Win
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 env:
   OPENBLAS_COMMIT: "v0.3.23"

--- a/.github/workflows/multibuild.yml
+++ b/.github/workflows/multibuild.yml
@@ -2,9 +2,9 @@ name: multibuild
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/multibuild.yml
+++ b/.github/workflows/multibuild.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch: null
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   build:
@@ -53,6 +56,7 @@ jobs:
     env:
       REPO_DIR: OpenBLAS
       OPENBLAS_COMMIT: "v0.3.23"
+      NIGHTLY: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
       MACOSX_DEPLOYMENT_TARGET: 10.9
       MB_PYTHON_VERSION: ${{ matrix.python-version }}
       TRAVIS_PYTHON_VERSION: ${{ matrix.python-version }}
@@ -105,7 +109,11 @@ jobs:
         echo "------ CLEAN CODE --------"
         clean_code $REPO_DIR $OPENBLAS_COMMIT
         echo "------ BUILD LIB --------"
-        build_lib "$PLAT" "$INTERFACE64"
+        if [[ "$NIGHTLY" = "true" ]]; then
+          build_lib "$PLAT" "$INTERFACE64" "1"
+        else
+          build_lib "$PLAT" "$INTERFACE64" "0"
+        fi
 
     - uses: actions/upload-artifact@v3
       with:
@@ -124,11 +132,18 @@ jobs:
             pip install git+https://github.com/Anaconda-Server/anaconda-client@1.8.0
             # The first -t option refers to the token, the second is the "type"
             # option to the "upload" command
-            anaconda -t  ${TOKEN} upload \
-            --no-progress --skip -u multibuild-wheels-staging \
-            -t file -p "openblas-libs" \
-            -v "$(cd OpenBLAS && git describe --tags --abbrev=8)" \
-            -d "OpenBLAS for multibuild wheels" \
-            -s "OpenBLAS for multibuild wheels" \
-            libs/openblas*.tar.gz;
+            args=(
+              -t ${TOKEN} upload
+              --no-progress -u multibuild-wheels-staging
+              -t file -p "openblas-libs"
+              -d "OpenBLAS for multibuild wheels"
+              -s "OpenBLAS for multibuild wheels"
+              -v "$(cd OpenBLAS && git describe --tags --abbrev=8)"
+            )
+            if [[ "$NIGHTLY" = "true" ]]; then
+              args+=(--force)
+            else
+              args+=(--skip)
+            fi
+            anaconda "${args[@]}" libs/openblas*.tar.gz
         fi

--- a/.github/workflows/multibuild.yml
+++ b/.github/workflows/multibuild.yml
@@ -119,6 +119,8 @@ jobs:
             # The token is available when under the MacPython org, not on forks
             echo "secrets.MULTIBUILD_WHEELS_STAGING_ACCESS is not defined: skipping";
         else
+            # Pin urllib3<2 due to github.com/Anaconda-Platform/anaconda-client/issues/654
+            pip install "urllib3<2.0.0"
             pip install git+https://github.com/Anaconda-Server/anaconda-client@1.8.0
             # The first -t option refers to the token, the second is the "type"
             # option to the "upload" command

--- a/travis-ci/docker_build_wrap.sh
+++ b/travis-ci/docker_build_wrap.sh
@@ -7,4 +7,4 @@ set -e
 # Change into root directory of repo
 cd /io
 source travis-ci/build_steps.sh
-do_build_lib "$PLAT" "" "$INTERFACE64"
+do_build_lib "$PLAT" "" "$INTERFACE64" "$NIGHTLY"


### PR DESCRIPTION
Resolves https://github.com/MacPython/openblas-libs/issues/100. 

As suggested by @MattiP, I've tackled this by having the nightly builds be uploaded to the same filenames with "HEAD" where the version would be. This is a crude approach compared to how other nightlies work (see [`scipy-wheels-nightly`](https://anaconda.org/scipy-wheels-nightly)), but should be fine for the purposes of testing NumPy and SciPy against OpenBLAS nightlies.

<details><summary>Example filenames</summary>

```
openblas-HEAD-musllinux_1_1_x86_64.tar.gz
openblas-HEAD-manylinux2014_x86_64.tar.gz
openblas64_-HEAD-musllinux_1_1_x86_64.tar.gz
openblas64_-HEAD-manylinux2014_x86_64.tar.gz
openblas64_-HEAD-manylinux2010_x86_64.tar.gz
openblas-HEAD-manylinux2014_i686.tar.gz
openblas-HEAD-manylinux2010_x86_64.tar.gz
openblas-HEAD-manylinux2010_i686.tar.gz
```

</details>

This PR is only generating linux builds (basically copy-pasted the `multibuild.yml` workflow). Some linux builds fail, which I can have a look at but might be a cakewalk to resolve for you folks :sweat_smile: As the new workflow runs on cron rather than push, you can look at https://github.com/honno/openblas-libs/pull/2 (test PR I made). From the latest [Actions run](https://github.com/honno/openblas-libs/actions/runs/5457702311), the following jobs are currently failing:

```
nightly multibuild / build (ubuntu-latest, x64, i686, 1)
nightly multibuild / build (ubuntu-latest, x64, i686, 1, 2010)
nightly multibuild / build (ubuntu-latest, x64, i686, 1, 2014)
```

</details>

Also note I removed Mac and Windows builds just so I could push a MVP on nightlies out the door, but I could re-instate Mac builds at least as they already work with `multibuild.yml` and thus should with `nightly_multibuild.yml` (although when I tried before they failed too).

cc @steppi