### PR TITLE
Update default branch references, pin `urllib3<2`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,5 +82,6 @@ jobs:
         env:
          OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN: ${{ secrets.MULTIBUILD_WHEELS_STAGING_ACCESS }}
         run: |
-          conda install anaconda-client
+          # Pin urllib3<2 due to github.com/Anaconda-Platform/anaconda-client/issues/654
+          conda install "urllib3<2" anaconda-client
           & $env:BASH_PATH -lc tools/upload_to_anaconda_staging.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Win
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 env:
   OPENBLAS_COMMIT: "v0.3.23"

--- a/.github/workflows/multibuild.yml
+++ b/.github/workflows/multibuild.yml
@@ -2,9 +2,9 @@ name: multibuild
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/multibuild.yml
+++ b/.github/workflows/multibuild.yml
@@ -119,6 +119,8 @@ jobs:
             # The token is available when under the MacPython org, not on forks
             echo "secrets.MULTIBUILD_WHEELS_STAGING_ACCESS is not defined: skipping";
         else
+            # Pin urllib3<2 due to github.com/Anaconda-Platform/anaconda-client/issues/654
+            pip install "urllib3<2.0.0"
             pip install git+https://github.com/Anaconda-Server/anaconda-client@1.8.0
             # The first -t option refers to the token, the second is the "type"
             # option to the "upload" command


### PR DESCRIPTION
I saw this repo just recently updated its default branch to `main` (was `master`), so I updated references to the default branch in the GH Action workflows.

Also resolves https://github.com/MacPython/openblas-libs/issues/102