### PR TITLE
Fix nightly mac builds not being named with "HEAD"

### DIFF
--- a/travis-ci/build_steps.sh
+++ b/travis-ci/build_steps.sh
@@ -73,7 +73,7 @@ function build_lib {
     # Make directory to store built archive
     if [ -n "$IS_OSX" ]; then
         # Do build, add gfortran hash to end of name
-        wrap_wheel_builder do_build_lib "$plat" "gf_${GFORTRAN_SHA:0:7}" "$interface64"
+        wrap_wheel_builder do_build_lib "$plat" "gf_${GFORTRAN_SHA:0:7}" "$interface64" "$nightly"
         return
     fi
     # Manylinux wrapper


### PR DESCRIPTION
Should resolve https://github.com/MacPython/openblas-libs/issues/100#issuecomment-1627755956

> The scheduled linux runs [look good](https://anaconda.org/multibuild-wheels-staging/openblas-libs/files). For some reason the macos ones apparently did not pick up the `NIGHTLY` environment variable, and built 0.3.23 tarballs.

I forgot to pass through the `$nightly` var for the OSX branch of logic :facepalm: 