### PR TITLE
Change version for nightly on anaconda to HEAD

### DIFF
--- a/.github/workflows/multibuild.yml
+++ b/.github/workflows/multibuild.yml
@@ -138,12 +138,13 @@ jobs:
               -t file -p "openblas-libs"
               -d "OpenBLAS for multibuild wheels"
               -s "OpenBLAS for multibuild wheels"
-              -v "$(cd OpenBLAS && git describe --tags --abbrev=8)"
             )
             if [[ "$NIGHTLY" = "true" ]]; then
               args+=(--force)
+              args+=(-v "HEAD")
             else
               args+=(--skip)
+              args+=(-v "$(cd OpenBLAS && git describe --tags --abbrev=8)")
             fi
             anaconda "${args[@]}" libs/openblas*.tar.gz
         fi


### PR DESCRIPTION
This PR resolves an issue that caused the path to nightly openblas-libs builds to contain the openblas version number instead of HEAD. Currently paths look like

```
https://anaconda.org/multibuild-wheels-staging/openblas-libs/v0.3.23/download/openblas64_-HEAD-manylinux2014_x86_64.tar.gz
```

instead of

```
https://anaconda.org/multibuild-wheels-staging/openblas-libs/HEAD/download/openblas64_-HEAD-manylinux2014_x86_64.tar.gz
```

@mattip identified that the issue is in the line `-v "$(cd OpenBLAS && git describe --tags --abbrev=8)"` that is in both `multibuild.yml` and `build_steps.sh``.

I've fixed both files. `multibuild.yml` was straightforward to fix because the script to upload to anaconda is aware of whether `NIGHTLY` is true. For `multibuild.yml` the function to upload to anaconda currently just searches for files matching the pattern `openblas*.tar.gz`. I've separated this into two function, one which matches `openblas*HEAD*.tar.gz`, and the other which matches all strings of the form `openblas*.tar.gz` which do not contain `"HEAD"`.




