### PR TITLE
INTERFACE64 cannot be blank

### DIFF
--- a/.github/workflows/multibuild.yml
+++ b/.github/workflows/multibuild.yml
@@ -21,7 +21,7 @@ jobs:
         os: [ubuntu-latest, macos-11]
         platform: [x64]
         PLAT: [i686, x86_64]
-        INTERFACE64: ['', '1']
+        INTERFACE64: ['0', '1']
         MB_ML_VER: ['', 2010, 2014]
         include:
           - os: macos-11
@@ -30,7 +30,7 @@ jobs:
             platform: [x64]
           - os: macos-11
             PLAT: arm64
-            INTERFACE64: ''
+            INTERFACE64: '0'
             platform: [x64]
           - os: ubuntu-latest
             PLAT: x86_64
@@ -40,7 +40,7 @@ jobs:
             platform: [x64]
           - os: ubuntu-latest
             PLAT: x86_64
-            INTERFACE64: ''
+            INTERFACE64: '0'
             MB_ML_LIBC: musllinux
             MB_ML_VER: _1_1
             platform: [x64]


### PR DESCRIPTION
since the code to use nightly added another parameter to `build_lib`, the INTERFACE64 parameter cannot be "", it must be "0". Otherwise, in the call to `build_lib "$PLAT" "$INTERFACE64" "1", the `1` is interpreted as the `INTERFACE64` argument.