### PR TITLE
use 8 characters in git describe on windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: install-rtools
         run: |
           # rtools 42+ does not support 32 bits builds.

--- a/.github/workflows/multibuild.yml
+++ b/.github/workflows/multibuild.yml
@@ -69,7 +69,7 @@ jobs:
       PLAT: ${{ matrix.PLAT }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
         fetch-depth: 0

--- a/tools/build_openblas.sh
+++ b/tools/build_openblas.sh
@@ -84,7 +84,7 @@ fi
 
 # Build name for output library from gcc version and OpenBLAS commit.
 GCC_TAG="gcc_$(gcc -dumpversion | tr .- _)"
-OPENBLAS_VERSION=$(git describe --tags)
+OPENBLAS_VERSION=$(git describe --tags --abbrev=8)
 # Build OpenBLAS
 # Variable used in creating output libraries
 export LIBNAMESUFFIX=${OPENBLAS_VERSION}-${GCC_TAG}

--- a/tools/upload_to_anaconda_staging.sh
+++ b/tools/upload_to_anaconda_staging.sh
@@ -6,7 +6,7 @@ our_wd=$(cygpath "$START_DIR")
 cd $our_wd
 
 pushd OpenBLAS
-VERSION=$(git describe --tags)
+VERSION=$(git describe --tags --abbrev=8)
 popd
 
 if [ "$OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN" == "" ]; then


### PR DESCRIPTION
The latest windows builds are using 9 characters instead of 8. Maybe something changed with git? In any case, using `--abbrev 8` should fix the problem