### PR TITLE
Upload to `scientific-python-nightly-wheels`, change nightly frequency to weekly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload
         env:
-          ANACONDA_SCIENTIFIC_PYTHON_UPLOAD: ${{ secrets.ANACONDA_SCIENTIFIC_PYTHON_UPLOAD }}
+         ANACONDA_SCIENTIFIC_PYTHON_UPLOAD: ${{ secrets.ANACONDA_SCIENTIFIC_PYTHON_UPLOAD }}
         run: |
           # Pin urllib3<2 due to github.com/Anaconda-Platform/anaconda-client/issues/654
           conda install "urllib3<2" anaconda-client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload
         env:
-         OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN: ${{ secrets.MULTIBUILD_WHEELS_STAGING_ACCESS }}
+         OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN: ${{ secrets.ANACONDA_SCIENTIFIC_PYTHON_UPLOAD }}
         run: |
           # Pin urllib3<2 due to github.com/Anaconda-Platform/anaconda-client/issues/654
           conda install "urllib3<2" anaconda-client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload
         env:
-         OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN: ${{ secrets.ANACONDA_SCIENTIFIC_PYTHON_UPLOAD }}
+          ANACONDA_SCIENTIFIC_PYTHON_UPLOAD: ${{ secrets.ANACONDA_SCIENTIFIC_PYTHON_UPLOAD }}
         run: |
           # Pin urllib3<2 due to github.com/Anaconda-Platform/anaconda-client/issues/654
           conda install "urllib3<2" anaconda-client

--- a/.github/workflows/multibuild.yml
+++ b/.github/workflows/multibuild.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
   workflow_dispatch: null
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 0'
 
 jobs:
   build:

--- a/.github/workflows/multibuild.yml
+++ b/.github/workflows/multibuild.yml
@@ -64,8 +64,6 @@ jobs:
       MB_ML_VER: ${{ matrix.MB_ML_VER }}
       INTERFACE64: ${{ matrix.INTERFACE64 }}
       BUILD_DIR: ${{ github.workspace }}
-      SCIPY_WHEELS_NIGHTLY_ACCESS: ${{ secrets.SCIPY_WHEELS_NIGHTLY_ACCESS }}
-      MULTIBUILD_WHEELS_STAGING_ACCESS: ${{ secrets.MULTIBUILD_WHEELS_STAGING_BUILD }}
       PLAT: ${{ matrix.PLAT }}
 
     steps:
@@ -127,10 +125,10 @@ jobs:
     - name: Upload tarballs
       run: |
         set -ex
-        TOKEN=${{ secrets.MULTIBUILD_WHEELS_STAGING_ACCESS }}
+        TOKEN=${{ secrets.ANACONDA_SCIENTIFIC_PYTHON_UPLOAD }}
         if [ "$TOKEN" == "" ]; then
             # The token is available when under the MacPython org, not on forks
-            echo "secrets.MULTIBUILD_WHEELS_STAGING_ACCESS is not defined: skipping";
+            echo "secrets.ANACONDA_SCIENTIFIC_PYTHON_UPLOAD is not defined: skipping";
         else
             # Pin urllib3<2 due to github.com/Anaconda-Platform/anaconda-client/issues/654
             pip install "urllib3<2.0.0"
@@ -139,7 +137,7 @@ jobs:
             # option to the "upload" command
             args=(
               -t ${TOKEN} upload
-              --no-progress -u multibuild-wheels-staging
+              --no-progress -u scientific-python-nightly-wheels
               -t file -p "openblas-libs"
               -d "OpenBLAS for multibuild wheels"
               -s "OpenBLAS for multibuild wheels"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a repository to trigger builds of OpenBLAS on Travis-CI (for aarch64,
 ppc64, s390x) and github actions for all the others.
 
 The OpenBLAS libraries get uploaded to
-https://anaconda.org/multibuild-wheels-staging/openblas-libs/files
+https://anaconda.org/scientific-python-nightly-wheels/openblas-libs/files
 
 A project using these libraries, for Manylinux or macOS, will need the
 ``gfortran-install`` submodule used here, from

--- a/tools/upload_to_anaconda_staging.sh
+++ b/tools/upload_to_anaconda_staging.sh
@@ -16,7 +16,7 @@ else
     ls -lh builds/openblas*.zip
 
     anaconda -t $OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN upload \
-            --no-progress --force -u multibuild-wheels-staging \
+            --no-progress --force -u scientific-python-nightly-wheels \
             -t file -p "openblas-libs" -v "$VERSION" \
             -d "OpenBLAS for multibuild wheels" \
             -s "OpenBLAS for multibuild wheels" \

--- a/tools/upload_to_anaconda_staging.sh
+++ b/tools/upload_to_anaconda_staging.sh
@@ -9,13 +9,13 @@ pushd OpenBLAS
 VERSION=$(git describe --tags --abbrev=8)
 popd
 
-if [ "$OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN" == "" ]; then
-    echo "OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN is not defined: skipping."
+if [ "$ANACONDA_SCIENTIFIC_PYTHON_UPLOAD" == "" ]; then
+    echo "ANACONDA_SCIENTIFIC_PYTHON_UPLOAD is not defined: skipping."
 else
     echo "Uploading OpenBLAS $VERSION to anaconda.org staging:"
     ls -lh builds/openblas*.zip
 
-    anaconda -t $OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN upload \
+    anaconda -t $ANACONDA_SCIENTIFIC_PYTHON_UPLOAD upload \
             --no-progress --force -u scientific-python-nightly-wheels \
             -t file -p "openblas-libs" -v "$VERSION" \
             -d "OpenBLAS for multibuild wheels" \

--- a/travis-ci/build_steps.sh
+++ b/travis-ci/build_steps.sh
@@ -196,10 +196,10 @@ function do_build_lib {
 }
 
 function upload_to_anaconda {
-    if [ "$OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN" == "" ]; then
-        echo "OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN is not defined: skipping."
+    if [ "$ANACONDA_SCIENTIFIC_PYTHON_UPLOAD" == "" ]; then
+        echo "ANACONDA_SCIENTIFIC_PYTHON_UPLOAD is not defined: skipping."
     else
-        anaconda -t $OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN upload \
+        anaconda -t $ANACONDA_SCIENTIFIC_PYTHON_UPLOAD upload \
             --no-progress --force -u scientific-python-nightly-wheels \
             -t file -p "openblas-libs" \
             -v "$(cd OpenBLAS && git describe --tags --abbrev=8)" \

--- a/travis-ci/build_steps.sh
+++ b/travis-ci/build_steps.sh
@@ -200,7 +200,7 @@ function upload_to_anaconda {
         echo "OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN is not defined: skipping."
     else
         anaconda -t $OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN upload \
-            --no-progress --force -u multibuild-wheels-staging \
+            --no-progress --force -u scientific-python-nightly-wheels \
             -t file -p "openblas-libs" \
             -v "$(cd OpenBLAS && git describe --tags --abbrev=8)" \
             -d "OpenBLAS for multibuild wheels" \


### PR DESCRIPTION
Resolves outstanding issues from https://github.com/MacPython/openblas-libs/issues/100#issuecomment-1630679025:
* Changes the frequency of the nightly linux/mac builds to once-a-week... so they're now really weeklies!
* Moves over ALL builds from [`multibuild-wheels-staging/openblas-libs`](https://anaconda.org/multibuild-wheels-staging/openblas-libs) to [`scientific-python-nightly-wheels/openblas-libs`](https://anaconda.org/scientific-python-nightly-wheels/openblas-libs)

cc @mattip @steppi