### PR TITLE
do not immediately on error

### DIFF
--- a/tools/upload_to_anaconda_staging.sh
+++ b/tools/upload_to_anaconda_staging.sh
@@ -2,6 +2,7 @@
 # Upload tar.gz and wheels to ananconda.org
 
 upload_wheels() {
+    set +e -x
     if [[ "$(uname -s)" == CYGWIN* ]]; then
         our_wd=$(cygpath "$START_DIR")
         cd $our_wd
@@ -23,7 +24,6 @@ upload_wheels() {
                 -d "OpenBLAS for multibuild wheels" \
                 -s "OpenBLAS for multibuild wheels" \
                 ${tarballs}
-                
 
         anaconda -t $ANACONDA_SCIENTIFIC_PYTHON_UPLOAD upload \
                 --no-progress --force -u scientific-python-nightly-wheels \


### PR DESCRIPTION
The ls command in the function will error, since only one kind of tarball (zip or tar.gz) will be present. I think that is causing the script to exit. Add `set -x` to report the commands, hopefully it will not expose the token?