### PR TITLE
redo pkgconfig file link and cflags, use RTLD_GLOBAL to load DLL, add download script

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -109,6 +109,7 @@ jobs:
             # of a pyproject.toml project
             sed -e "s/openblas64/openblas32/" -i pyproject.toml
             sed -e "s/openblas_get_config64_/openblas_get_config/" -i local/scipy_openblas32/__init__.py
+            sed -e "s/cflags_suffix64 =.*/cflags_suffix64 = ''/" -i local/scipy_openblas32/__init__.py
             sed -e "s/openblas64/openblas32/" -i local/scipy_openblas32/__init__.py
             sed -e "s/openblas64/openblas32/" -i local/scipy_openblas32/__main__.py
         fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scipy_openblas64"
-version = "0.3.23.293.1"
+version = "0.3.23.293.2"
 requires-python = ">=3.7"
 description = "Provides OpenBLAS for python packaging"
 readme = "README.md"

--- a/tools/build_wheel.sh
+++ b/tools/build_wheel.sh
@@ -45,6 +45,7 @@ if [ "${INTERFACE64}" != "1" ]; then
     rm *.bak
     mv local/scipy_openblas64 local/scipy_openblas32
     sed -e "s/openblas_get_config64_/openblas_get_config/" -i.bak local/scipy_openblas32/__init__.py
+    sed -e "s/cflags_suffix64 =.*/cflags_suffix64 = ''/" -i.bak local/scipy_openblas32/__init__.py
     sed -e "s/openblas64/openblas32/" -i.bak local/scipy_openblas32/__main__.py
     sed -e "s/openblas64/openblas32/" -i.bak local/scipy_openblas32/__init__.py
     rm local/scipy_openblas32/*.bak

--- a/tools/download-wheels.py
+++ b/tools/download-wheels.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Script to download NumPy wheels from the Anaconda staging area.
+
+Usage::
+
+    $ ./tools/download-wheels.py <version> -w <optional-wheelhouse>
+
+The default wheelhouse is ``release/installers``.
+
+Dependencies
+------------
+
+- beautifulsoup4
+- urllib3
+
+Examples
+--------
+
+While in the repository root::
+
+    $ python tools/download-wheels.py 1.19.0
+    $ python tools/download-wheels.py 1.19.0 -w ~/wheelhouse
+
+"""
+import os
+import re
+import shutil
+import argparse
+
+import urllib3
+from bs4 import BeautifulSoup
+
+__version__ = "0.1"
+
+# Edit these for other projects.
+URL = "https://anaconda.org/scientific-python-nightly-wheels"
+
+# Name endings of the files to download.
+WHL = r"-.*\.whl$"
+ZIP = r"\.zip$"
+GZIP = r"\.tar\.gz$"
+SUFFIX = rf"({WHL}|{GZIP}|{ZIP})"
+
+
+def get_wheel_names(package, version):
+    """ Get wheel names from Anaconda HTML directory.
+
+    This looks in the Anaconda multibuild-wheels-staging page and
+    parses the HTML to get all the wheel names for a release version.
+
+    Parameters
+    ----------
+    version : str
+        The release version. For instance, "1.18.3".
+
+    """
+    http = urllib3.PoolManager(cert_reqs="CERT_REQUIRED")
+    tmpl = re.compile(rf"^.*{package.replace('-', '_')}-{version}{SUFFIX}")
+    index_url = f"{URL}/{package}/files"
+    index_html = http.request("GET", index_url)
+    soup = BeautifulSoup(index_html.data, "html.parser")
+    return soup.find_all(string=tmpl)
+
+
+def download_wheels(package, version, wheelhouse):
+    """Download release wheels.
+
+    The release wheels for the given package version are downloaded
+    into the given directory.
+
+    Parameters
+    ----------
+    package : str
+        The package to download, scipy-openblas32 or scipy-openblas64
+    version : str
+        The release version. For instance, "1.18.3".
+    wheelhouse : str
+        Directory in which to download the wheels.
+
+    """
+    http = urllib3.PoolManager(cert_reqs="CERT_REQUIRED")
+    wheel_names = get_wheel_names(package, version)
+
+    for i, wheel_name in enumerate(wheel_names):
+        wheel_url = f"{URL}/{package}/{version}/download/{wheel_name}"
+        wheel_path = os.path.join(wheelhouse, wheel_name)
+        with open(wheel_path, "wb") as f:
+            with http.request("GET", wheel_url, preload_content=False,) as r:
+                print(f"{i + 1:<4}{wheel_name}")
+                shutil.copyfileobj(r, f)
+    print(f"\nTotal files downloaded: {len(wheel_names)}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--package",
+        required=True,
+        help="package to download.")
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="package version to download.")
+    parser.add_argument(
+        "-w", "--wheelhouse",
+        default=os.path.join(os.getcwd(), "release", "installers"),
+        help="Directory in which to store downloaded wheels\n"
+             "[defaults to <cwd>/release/installers]")
+
+    args = parser.parse_args()
+
+    wheelhouse = os.path.expanduser(args.wheelhouse)
+    if not os.path.isdir(wheelhouse):
+        raise RuntimeError(
+            f"{wheelhouse} wheelhouse directory is not present."
+            " Perhaps you need to use the '-w' flag to specify one.")
+
+    download_wheels(args.package, args.version, wheelhouse)

--- a/tools/upload_to_anaconda_staging.sh
+++ b/tools/upload_to_anaconda_staging.sh
@@ -2,7 +2,7 @@
 # Upload tar.gz and wheels to ananconda.org
 
 upload_wheels() {
-    set +e -x
+    set -x
     if [[ "$(uname -s)" == CYGWIN* ]]; then
         our_wd=$(cygpath "$START_DIR")
         cd $our_wd
@@ -17,7 +17,7 @@ upload_wheels() {
     else
         echo "Uploading OpenBLAS $VERSION to anaconda.org staging:"
 
-        tarballs=$(ls -d builds/openblas*.zip libs/openblas*.tar.gz 2>/dev/null)
+        tarballs=$(ls -d builds/openblas*.zip libs/openblas*.tar.gz 2>/dev/null && true)
         anaconda -t $ANACONDA_SCIENTIFIC_PYTHON_UPLOAD upload \
                 --no-progress --force -u scientific-python-nightly-wheels \
                 -t file -p "openblas-libs" -v "$VERSION" \


### PR DESCRIPTION
Changes needed for better interactions with numpy

- musllinux requires opening the dll with RTLD_GLOBAL
- on linux, when building a shared object, do not link to libopenblas_python. Rather leave the symbols undefined. Linking to the libopenblas_python.so adds a `NEEDS libopenblas_python.so` header to the linked SO, and makes it fail to load.
- instead, add libopenblas_python (and more) to the `Libs.private` section of the pkgconfig file, so `pkg-config --static --lib` will correctly link to it (needed for testing in numpy/meson.build)
- Add the needed cflags to build when using the 64-bit interfaces `-DBLAS_SYMBOL_SUFFIX=64_ -DHAVE_BLAS_ILP64`, and remove them for the 32-bit wheel. This will simplify using `pip install .`.
- Add a script to download all the wheels from a specific version