### PR TITLE
create a single shared object libscipy_openblas64_.so or libscipy_openblas.so

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -46,7 +46,7 @@ jobs:
             INTERFACE64: '1'
     env:
       REPO_DIR: OpenBLAS
-      OPENBLAS_COMMIT: "9d425a5f"
+      OPENBLAS_COMMIT: "v0.3.26"
       NIGHTLY: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
       MACOSX_DEPLOYMENT_TARGET: 10.9
       MB_PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 env:
-  OPENBLAS_COMMIT: "9d425a5f"
+  OPENBLAS_COMMIT: "v0.3.26"
   OPENBLAS_ROOT: "c:\\opt"
   # Preserve working directory for calls into bash
   # Without this, invoking bash will cd to the home directory

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
     global:
         # The archive that gets built has name from ``git describe`` on this
         # commit.
-        - OPENBLAS_COMMIT="9d425a5f"
+        - OPENBLAS_COMMIT="v0.3.26"
         - REPO_DIR=OpenBLAS
         # Following generated with:
         # travis encrypt -r MacPython/openblas-libs OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN=<secret token value>

--- a/local/scipy_openblas64/__init__.py
+++ b/local/scipy_openblas64/__init__.py
@@ -62,7 +62,7 @@ def get_pkg_config():
         libs_flags = f"-L${{libdir}} -l{get_library()}"
     else:
         extralib = f"-lm -lpthread -lgfortran -lquadmath -L${{libdir}} -l{get_library()}"
-        libs_flags = ""
+        libs_flags = "-L${{libdir}} -l{get_library()}"
     cflags = "-DBLAS_SYMBOL_PREFIX=scipy_ -DBLAS_SYMBOL_SUFFIX=64_ -DHAVE_BLAS_ILP64 -DOPENBLAS_ILP64_NAMING_SCHEME"
     return dedent(f"""\
         libdir={get_lib_dir()}

--- a/patches/0001-build-a-single-shared-object.patch
+++ b/patches/0001-build-a-single-shared-object.patch
@@ -1,13 +1,14 @@
-From f3f6eeba8e569e66a0f92b9e58f8465924f636f4 Mon Sep 17 00:00:00 2001
+From 7203d885e0b88128d2b2252956d21c0000888de4 Mon Sep 17 00:00:00 2001
 From: mattip <matti.picus@gmail.com>
-Date: Fri, 19 Jan 2024 15:13:13 +0200
-Subject: [PATCH] build a single shared object
+Date: Fri, 19 Jan 2024 17:15:06 +0200
+Subject: [PATCH] create a single shared object
 
 ---
- Makefile         | 5 -----
- Makefile.system  | 3 +++
- exports/Makefile | 4 ++--
- 3 files changed, 5 insertions(+), 7 deletions(-)
+ Makefile         |  5 -----
+ Makefile.install | 11 -----------
+ Makefile.system  |  3 +++
+ exports/Makefile |  4 ++--
+ 4 files changed, 5 insertions(+), 18 deletions(-)
 
 diff --git a/Makefile b/Makefile
 index 8621a8b3f..0febfd0a6 100644
@@ -31,6 +32,57 @@ index 8621a8b3f..0febfd0a6 100644
  endif
  ifeq ($(OSNAME), WINNT)
  	@$(MAKE) -C exports dll
+diff --git a/Makefile.install b/Makefile.install
+index 01899b970..7dee121c1 100644
+--- a/Makefile.install
++++ b/Makefile.install
+@@ -90,30 +90,22 @@ endif
+ ifneq ($(NO_STATIC),1)
+ 	@echo Copying the static library to $(DESTDIR)$(OPENBLAS_LIBRARY_DIR)
+ 	@install -m644 $(LIBNAME) "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)"
+-	@cd "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)" ; \
+-	ln -fs $(LIBNAME) $(LIBPREFIX).$(LIBSUFFIX)
+ endif
+ #for install shared library
+ ifneq ($(NO_SHARED),1)
+ 	@echo Copying the shared library to $(DESTDIR)$(OPENBLAS_LIBRARY_DIR)
+ ifeq ($(OSNAME), $(filter $(OSNAME),Linux SunOS Android Haiku FreeBSD DragonFly))
+ 	@install -m755 $(LIBSONAME) "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)"
+-	@cd "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)" ; \
+-	ln -fs $(LIBSONAME) $(LIBPREFIX).so ; \
+-	ln -fs $(LIBSONAME) $(LIBPREFIX).so.$(MAJOR_VERSION)
+ endif
+ 
+ ifeq ($(OSNAME), $(filter $(OSNAME),OpenBSD NetBSD))
+ 	@cp $(LIBSONAME) "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)"
+ 	@cd "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)" ; \
+-	ln -fs $(LIBSONAME) $(LIBPREFIX).so
+ endif
+ ifeq ($(OSNAME), Darwin)
+ 	@-cp $(LIBDYNNAME) "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)"
+ 	@-install_name_tool -id "$(OPENBLAS_LIBRARY_DIR)/$(LIBPREFIX).$(MAJOR_VERSION).dylib" "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)/$(LIBDYNNAME)"
+ 	@cd "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)" ; \
+-	ln -fs $(LIBDYNNAME) $(LIBPREFIX).dylib ; \
+-	ln -fs $(LIBDYNNAME) $(LIBPREFIX).$(MAJOR_VERSION).dylib
+ endif
+ ifeq ($(OSNAME), WINNT)
+ 	@-cp $(LIBDLLNAME) "$(DESTDIR)$(OPENBLAS_BINARY_DIR)"
+@@ -141,15 +133,12 @@ ifneq ($(NO_STATIC),1)
+ 	@echo Copying the static library to $(DESTDIR)$(OPENBLAS_LIBRARY_DIR)
+ 	@installbsd -c -m 644 $(LIBNAME) "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)"
+ 	@cd "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)" ; \
+-	ln -fs $(LIBNAME) $(LIBPREFIX).$(LIBSUFFIX)
+ endif
+ #for install shared library
+ ifneq ($(NO_SHARED),1)
+ 	@echo Copying the shared library to $(DESTDIR)$(OPENBLAS_LIBRARY_DIR)
+ 	@installbsd -c -m 755 $(LIBSONAME) "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)"
+ 	@cd "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)" ; \
+-	ln -fs $(LIBSONAME) $(LIBPREFIX).so ; \
+-	ln -fs $(LIBSONAME) $(LIBPREFIX).so.$(MAJOR_VERSION)
+ endif
+ 
+ endif
 diff --git a/Makefile.system b/Makefile.system
 index 30b0ddec2..b2c92b99a 100644
 --- a/Makefile.system

--- a/patches/0001-build-a-single-shared-object.patch
+++ b/patches/0001-build-a-single-shared-object.patch
@@ -1,0 +1,72 @@
+From f3f6eeba8e569e66a0f92b9e58f8465924f636f4 Mon Sep 17 00:00:00 2001
+From: mattip <matti.picus@gmail.com>
+Date: Fri, 19 Jan 2024 15:13:13 +0200
+Subject: [PATCH] build a single shared object
+
+---
+ Makefile         | 5 -----
+ Makefile.system  | 3 +++
+ exports/Makefile | 4 ++--
+ 3 files changed, 5 insertions(+), 7 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 8621a8b3f..0febfd0a6 100644
+--- a/Makefile
++++ b/Makefile
+@@ -134,17 +134,12 @@ shared : libs netlib $(RELA)
+ ifneq ($(NO_SHARED), 1)
+ ifeq ($(OSNAME), $(filter $(OSNAME),Linux SunOS Android Haiku FreeBSD DragonFly))
+ 	@$(MAKE) -C exports so
+-	@ln -fs $(LIBSONAME) $(LIBPREFIX).so
+-	@ln -fs $(LIBSONAME) $(LIBPREFIX).so.$(MAJOR_VERSION)
+ endif
+ ifeq ($(OSNAME), $(filter $(OSNAME),OpenBSD NetBSD))
+ 	@$(MAKE) -C exports so
+-	@ln -fs $(LIBSONAME) $(LIBPREFIX).so
+ endif
+ ifeq ($(OSNAME), Darwin)
+ 	@$(MAKE) -C exports dyn
+-	@ln -fs $(LIBDYNNAME) $(LIBPREFIX).dylib
+-	@ln -fs $(LIBDYNNAME) $(LIBPREFIX).$(MAJOR_VERSION).dylib
+ endif
+ ifeq ($(OSNAME), WINNT)
+ 	@$(MAKE) -C exports dll
+diff --git a/Makefile.system b/Makefile.system
+index 30b0ddec2..b2c92b99a 100644
+--- a/Makefile.system
++++ b/Makefile.system
+@@ -1695,6 +1695,9 @@ LIBNAME_P	= $(LIBPREFIX)p$(REVISION)_p.$(LIBSUFFIX)
+ endif
+ endif
+ 
++# Override for scipy-openblas: don't put the revision into the so name
++LIBNAME		= $(LIBPREFIX).$(LIBSUFFIX)
++LIBNAME_P	= $(LIBPREFIX)_p.$(LIBSUFFIX)
+ 
+ LIBDLLNAME   = $(LIBPREFIX).dll
+ IMPLIBNAME   = lib$(LIBNAMEBASE).dll.a
+diff --git a/exports/Makefile b/exports/Makefile
+index 7682f851d..632fa324b 100644
+--- a/exports/Makefile
++++ b/exports/Makefile
+@@ -132,7 +132,7 @@ libgoto_hpl.def : $(GENSYM)
+ 	./$(GENSYM) win2khpl $(ARCH) dummy $(EXPRECISION) $(NO_CBLAS) $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) "$(SYMBOLPREFIX)" "$(SYMBOLSUFFIX)" $(BUILD_LAPACK_DEPRECATED) $(BUILD_BFLOAT16) $(BUILD_SINGLE) $(BUILD_DOUBLE) $(BUILD_COMPLEX) $(BUILD_COMPLEX16) > $(@F)
+ 
+ ifeq ($(OSNAME), Darwin)
+-INTERNALNAME = $(LIBPREFIX).$(MAJOR_VERSION).dylib
++INTERNALNAME = $(LIBPREFIX).dylib
+ endif
+ 
+ ifeq (, $(SYMBOLPREFIX)$(SYMBOLSUFFIX))
+@@ -169,7 +169,7 @@ INTERNALNAME = $(LIBPREFIX).so
+ FEXTRALIB += -lm
+ EXTRALIB += -lm
+ else
+-INTERNALNAME = $(LIBPREFIX).so.$(MAJOR_VERSION)
++INTERNALNAME = $(LIBPREFIX).so
+ endif
+ 
+ ifeq (, $(SYMBOLPREFIX)$(SYMBOLSUFFIX))
+-- 
+2.34.1
+

--- a/patches/0001-create-a-single-shared-object.patch
+++ b/patches/0001-create-a-single-shared-object.patch
@@ -1,4 +1,4 @@
-From e5f32d54b742caf4e59ef6e7ec0caa16b7f670d3 Mon Sep 17 00:00:00 2001
+From 258ad2ccebe93fa9c5ad74a17c603b3fb8925190 Mon Sep 17 00:00:00 2001
 From: mattip <matti.picus@gmail.com>
 Date: Sun, 21 Jan 2024 22:34:48 +0200
 Subject: [PATCH] create a single shared object
@@ -72,7 +72,7 @@ index 8621a8b3f..56a449306 100644
  	do if test -d $$d; then \
  	  $(MAKE) -C $$d $(@F) || exit 1 ; \
 diff --git a/Makefile.install b/Makefile.install
-index 01899b970..958fb9957 100644
+index 01899b970..cf3c8acce 100644
 --- a/Makefile.install
 +++ b/Makefile.install
 @@ -90,30 +90,20 @@ endif
@@ -127,7 +127,7 @@ index 01899b970..958fb9957 100644
  
  	@echo Generating $(LIBSONAMEBASE)$(SUFFIX64).pc in "$(DESTDIR)$(OPENBLAS_PKGCONFIG_DIR)"
  	@echo 'libdir='$(OPENBLAS_LIBRARY_DIR) > "$(PKGFILE)"
-+	@echo 'libprefix='$(SYBOLPREFIX) > "$(PKGFILE)"
++	@echo 'libprefix='$(SYMBOLPREFIX) >> "$(PKGFILE)"
  	@echo 'libsuffix='$(SYMBOLSUFFIX) >> "$(PKGFILE)"
  	@echo 'includedir='$(OPENBLAS_INCLUDE_DIR) >> "$(PKGFILE)"
  	@echo 'openblas_config= USE_64BITINT='$(INTERFACE64) 'DYNAMIC_ARCH='$(DYNAMIC_ARCH) 'DYNAMIC_OLDER='$(DYNAMIC_OLDER) 'NO_CBLAS='$(NO_CBLAS) 'NO_LAPACK='$(NO_LAPACK) 'NO_LAPACKE='$(NO_LAPACKE) 'NO_AFFINITY='$(NO_AFFINITY) 'USE_OPENMP='$(USE_OPENMP) $(CORE) 'MAX_THREADS='$(NUM_THREADS)>> "$(PKGFILE)"

--- a/patches/0001-create-a-single-shared-object.patch
+++ b/patches/0001-create-a-single-shared-object.patch
@@ -1,14 +1,15 @@
-From 80863b52c024ed2d5fda80546e7b6a0160531b9a Mon Sep 17 00:00:00 2001
+From e5f32d54b742caf4e59ef6e7ec0caa16b7f670d3 Mon Sep 17 00:00:00 2001
 From: mattip <matti.picus@gmail.com>
-Date: Sun, 21 Jan 2024 08:35:54 +0200
+Date: Sun, 21 Jan 2024 22:34:48 +0200
 Subject: [PATCH] create a single shared object
 
 ---
  Makefile         | 10 ----------
- Makefile.install | 15 ---------------
+ Makefile.install | 16 +---------------
  Makefile.system  |  3 +++
  exports/Makefile |  4 ++--
- 4 files changed, 5 insertions(+), 27 deletions(-)
+ openblas.pc.in   |  2 +-
+ 5 files changed, 7 insertions(+), 28 deletions(-)
 
 diff --git a/Makefile b/Makefile
 index 8621a8b3f..56a449306 100644
@@ -71,7 +72,7 @@ index 8621a8b3f..56a449306 100644
  	do if test -d $$d; then \
  	  $(MAKE) -C $$d $(@F) || exit 1 ; \
 diff --git a/Makefile.install b/Makefile.install
-index 01899b970..105bc4271 100644
+index 01899b970..958fb9957 100644
 --- a/Makefile.install
 +++ b/Makefile.install
 @@ -90,30 +90,20 @@ endif
@@ -122,6 +123,14 @@ index 01899b970..105bc4271 100644
  endif
  
  endif
+@@ -162,6 +147,7 @@ endif
+ 
+ 	@echo Generating $(LIBSONAMEBASE)$(SUFFIX64).pc in "$(DESTDIR)$(OPENBLAS_PKGCONFIG_DIR)"
+ 	@echo 'libdir='$(OPENBLAS_LIBRARY_DIR) > "$(PKGFILE)"
++	@echo 'libprefix='$(SYBOLPREFIX) > "$(PKGFILE)"
+ 	@echo 'libsuffix='$(SYMBOLSUFFIX) >> "$(PKGFILE)"
+ 	@echo 'includedir='$(OPENBLAS_INCLUDE_DIR) >> "$(PKGFILE)"
+ 	@echo 'openblas_config= USE_64BITINT='$(INTERFACE64) 'DYNAMIC_ARCH='$(DYNAMIC_ARCH) 'DYNAMIC_OLDER='$(DYNAMIC_OLDER) 'NO_CBLAS='$(NO_CBLAS) 'NO_LAPACK='$(NO_LAPACK) 'NO_LAPACKE='$(NO_LAPACKE) 'NO_AFFINITY='$(NO_AFFINITY) 'USE_OPENMP='$(USE_OPENMP) $(CORE) 'MAX_THREADS='$(NUM_THREADS)>> "$(PKGFILE)"
 diff --git a/Makefile.system b/Makefile.system
 index 30b0ddec2..b2c92b99a 100644
 --- a/Makefile.system
@@ -158,6 +167,18 @@ index 7682f851d..632fa324b 100644
  endif
  
  ifeq (, $(SYMBOLPREFIX)$(SYMBOLSUFFIX))
+diff --git a/openblas.pc.in b/openblas.pc.in
+index 8ad6e8bee..33209293d 100644
+--- a/openblas.pc.in
++++ b/openblas.pc.in
+@@ -2,6 +2,6 @@ Name: openblas
+ Description: OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version
+ Version: ${version}
+ URL: https://github.com/xianyi/OpenBLAS
+-Libs: -L${libdir} -lopenblas${libsuffix}
++Libs: -L${libdir} -l${libprefix}openblas${libsuffix}
+ Libs.private: ${extralib}
+ Cflags: -I${includedir}
 -- 
 2.34.1
 

--- a/patches/0001-create-a-single-shared-object.patch
+++ b/patches/0001-create-a-single-shared-object.patch
@@ -1,17 +1,17 @@
-From ebca632fd6a3b41643d2cd51da37c6c199e915be Mon Sep 17 00:00:00 2001
+From 80863b52c024ed2d5fda80546e7b6a0160531b9a Mon Sep 17 00:00:00 2001
 From: mattip <matti.picus@gmail.com>
-Date: Sat, 20 Jan 2024 23:34:21 +0200
+Date: Sun, 21 Jan 2024 08:35:54 +0200
 Subject: [PATCH] create a single shared object
 
 ---
- Makefile         |  5 -----
+ Makefile         | 10 ----------
  Makefile.install | 15 ---------------
  Makefile.system  |  3 +++
  exports/Makefile |  4 ++--
- 4 files changed, 5 insertions(+), 22 deletions(-)
+ 4 files changed, 5 insertions(+), 27 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index 8621a8b3f..0febfd0a6 100644
+index 8621a8b3f..56a449306 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -134,17 +134,12 @@ shared : libs netlib $(RELA)
@@ -32,6 +32,44 @@ index 8621a8b3f..0febfd0a6 100644
  endif
  ifeq ($(OSNAME), WINNT)
  	@$(MAKE) -C exports dll
+@@ -213,13 +208,11 @@ endif
+ ifdef USE_THREAD
+ 	@echo USE_THREAD=$(USE_THREAD) >>  Makefile.conf_last
+ endif
+-	@-ln -fs $(LIBNAME) $(LIBPREFIX).$(LIBSUFFIX)
+ 	@touch lib.grd
+ 
+ prof : prof_blas prof_lapack
+ 
+ prof_blas :
+-	ln -fs $(LIBNAME_P) $(LIBPREFIX)_p.$(LIBSUFFIX)
+ 	for d in $(SUBDIRS) ; \
+ 	do if test -d $$d; then \
+ 	  $(MAKE) -C $$d prof || exit 1 ; \
+@@ -230,7 +223,6 @@ ifeq ($(DYNAMIC_ARCH), 1)
+ endif
+ 
+ blas :
+-	ln -fs $(LIBNAME) $(LIBPREFIX).$(LIBSUFFIX)
+ 	for d in $(BLASDIRS) ; \
+ 	do if test -d $$d; then \
+ 	  $(MAKE) -C $$d libs || exit 1 ; \
+@@ -238,7 +230,6 @@ blas :
+ 	done
+ 
+ hpl :
+-	ln -fs $(LIBNAME) $(LIBPREFIX).$(LIBSUFFIX)
+ 	for d in $(BLASDIRS) ../laswp exports ; \
+ 	do if test -d $$d; then \
+ 	  $(MAKE) -C $$d $(@F) || exit 1 ; \
+@@ -252,7 +243,6 @@ ifeq ($(DYNAMIC_ARCH), 1)
+ endif
+ 
+ hpl_p :
+-	ln -fs $(LIBNAME_P) $(LIBPREFIX)_p.$(LIBSUFFIX)
+ 	for d in $(SUBDIRS) ../laswp exports ; \
+ 	do if test -d $$d; then \
+ 	  $(MAKE) -C $$d $(@F) || exit 1 ; \
 diff --git a/Makefile.install b/Makefile.install
 index 01899b970..105bc4271 100644
 --- a/Makefile.install

--- a/patches/0001-create-a-single-shared-object.patch
+++ b/patches/0001-create-a-single-shared-object.patch
@@ -1,14 +1,14 @@
-From 7203d885e0b88128d2b2252956d21c0000888de4 Mon Sep 17 00:00:00 2001
+From ebca632fd6a3b41643d2cd51da37c6c199e915be Mon Sep 17 00:00:00 2001
 From: mattip <matti.picus@gmail.com>
-Date: Fri, 19 Jan 2024 17:15:06 +0200
+Date: Sat, 20 Jan 2024 23:34:21 +0200
 Subject: [PATCH] create a single shared object
 
 ---
  Makefile         |  5 -----
- Makefile.install | 11 -----------
+ Makefile.install | 15 ---------------
  Makefile.system  |  3 +++
  exports/Makefile |  4 ++--
- 4 files changed, 5 insertions(+), 18 deletions(-)
+ 4 files changed, 5 insertions(+), 22 deletions(-)
 
 diff --git a/Makefile b/Makefile
 index 8621a8b3f..0febfd0a6 100644
@@ -33,10 +33,10 @@ index 8621a8b3f..0febfd0a6 100644
  ifeq ($(OSNAME), WINNT)
  	@$(MAKE) -C exports dll
 diff --git a/Makefile.install b/Makefile.install
-index 01899b970..7dee121c1 100644
+index 01899b970..105bc4271 100644
 --- a/Makefile.install
 +++ b/Makefile.install
-@@ -90,30 +90,22 @@ endif
+@@ -90,30 +90,20 @@ endif
  ifneq ($(NO_STATIC),1)
  	@echo Copying the static library to $(DESTDIR)$(OPENBLAS_LIBRARY_DIR)
  	@install -m644 $(LIBNAME) "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)"
@@ -55,29 +55,30 @@ index 01899b970..7dee121c1 100644
  
  ifeq ($(OSNAME), $(filter $(OSNAME),OpenBSD NetBSD))
  	@cp $(LIBSONAME) "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)"
- 	@cd "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)" ; \
+-	@cd "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)" ; \
 -	ln -fs $(LIBSONAME) $(LIBPREFIX).so
  endif
  ifeq ($(OSNAME), Darwin)
  	@-cp $(LIBDYNNAME) "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)"
  	@-install_name_tool -id "$(OPENBLAS_LIBRARY_DIR)/$(LIBPREFIX).$(MAJOR_VERSION).dylib" "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)/$(LIBDYNNAME)"
- 	@cd "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)" ; \
+-	@cd "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)" ; \
 -	ln -fs $(LIBDYNNAME) $(LIBPREFIX).dylib ; \
 -	ln -fs $(LIBDYNNAME) $(LIBPREFIX).$(MAJOR_VERSION).dylib
  endif
  ifeq ($(OSNAME), WINNT)
  	@-cp $(LIBDLLNAME) "$(DESTDIR)$(OPENBLAS_BINARY_DIR)"
-@@ -141,15 +133,12 @@ ifneq ($(NO_STATIC),1)
+@@ -140,16 +130,11 @@ endif
+ ifneq ($(NO_STATIC),1)
  	@echo Copying the static library to $(DESTDIR)$(OPENBLAS_LIBRARY_DIR)
  	@installbsd -c -m 644 $(LIBNAME) "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)"
- 	@cd "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)" ; \
+-	@cd "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)" ; \
 -	ln -fs $(LIBNAME) $(LIBPREFIX).$(LIBSUFFIX)
  endif
  #for install shared library
  ifneq ($(NO_SHARED),1)
  	@echo Copying the shared library to $(DESTDIR)$(OPENBLAS_LIBRARY_DIR)
  	@installbsd -c -m 755 $(LIBSONAME) "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)"
- 	@cd "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)" ; \
+-	@cd "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)" ; \
 -	ln -fs $(LIBSONAME) $(LIBPREFIX).so ; \
 -	ln -fs $(LIBSONAME) $(LIBPREFIX).so.$(MAJOR_VERSION)
  endif

--- a/patches/0001-create-a-single-shared-object.patch
+++ b/patches/0001-create-a-single-shared-object.patch
@@ -33,10 +33,10 @@ index 8621a8b3f..56a449306 100644
  endif
  ifeq ($(OSNAME), WINNT)
  	@$(MAKE) -C exports dll
-@@ -213,13 +208,11 @@ endif
- ifdef USE_THREAD
- 	@echo USE_THREAD=$(USE_THREAD) >>  Makefile.conf_last
+@@ -229,13 +225,11 @@ endif
  endif
+ 	@echo THELIBNAME=$(LIBNAME) >>  Makefile.conf_last
+ 	@echo THELIBSONAME=$(LIBSONAME) >>  Makefile.conf_last
 -	@-ln -fs $(LIBNAME) $(LIBPREFIX).$(LIBSUFFIX)
  	@touch lib.grd
  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scipy_openblas64"
-version = "0.3.24.95.1"
+version = "0.3.24.95.2"
 requires-python = ">=3.7"
 description = "Provides OpenBLAS for python packaging"
 readme = "README.md"

--- a/tools/build_openblas.sh
+++ b/tools/build_openblas.sh
@@ -122,7 +122,7 @@ cp -f "${static_libname}.renamed" "$openblas_root/$build_bits/lib/${DLL_BASENAME
 
 cd $openblas_root
 # Copy library link file for custom name
-cd $build_bits/lib
+pushd $build_bits/lib
 cp ${our_wd}/OpenBLAS/exports/${DLL_BASENAME}.def ${DLL_BASENAME}.def
 # At least for the mingwpy wheel, we have to use the VC tools to build the
 # export library. Maybe fixed in later binutils by patch referred to in
@@ -135,7 +135,8 @@ dlltool --input-def ${DLL_BASENAME}.def \
     --output-lib ${DLL_BASENAME}.lib
 # Replace the DLL name with the generated name.
 sed -i "s/ -lopenblas.*$/ -l${DLL_BASENAME:3}/g" pkgconfig/openblas*.pc
-cd ../..
+mv pkgconfig/*.pc pkgconfig/scipy-openblas.pc
+popd
 # Build template site.cfg for using this build
 cat > ${build_bits}/site.cfg.template << EOF
 [openblas${SYMBOLSUFFIX}]

--- a/tools/build_openblas.sh
+++ b/tools/build_openblas.sh
@@ -136,6 +136,11 @@ dlltool --input-def ${DLL_BASENAME}.def \
 # Replace the DLL name with the generated name.
 sed -i "s/ -lopenblas.*$/ -l${DLL_BASENAME:3}/g" pkgconfig/openblas*.pc
 mv pkgconfig/*.pc pkgconfig/scipy-openblas.pc
+if [ "$if_bits" == "64" ]; then
+    sed -e "s/^Cflags.*/\0 -DBLAS_SYMBOL_PREFIX=scipy_ -DBLAS_SYMBOL_SUFFIX=64_/" -i pkgconfig/scipy-openblas.pc
+else
+    sed -e "s/^Cflags.*/\0 -DBLAS_SYMBOL_PREFIX=scipy_/" -i pkgconfig/scipy-openblas.pc
+fi
 popd
 # Build template site.cfg for using this build
 cat > ${build_bits}/site.cfg.template << EOF

--- a/tools/build_steps.sh
+++ b/tools/build_steps.sh
@@ -190,12 +190,14 @@ function do_build_lib {
         cp -f "OpenBLAS/${renamed_libname}" "$BUILD_PREFIX/lib/${static_libname}"
         # set +x
     fi
+    mv $BUILD_PREFIX/lib/pkgconfig/openblas*.pc $BUILD_PREFIX/lib/pkgconfig/scipy-openblas.pc
+
     local out_name="openblas${symbolsuffix}-${version}-${plat_tag}${suff}.tar.gz"
     tar zcvf libs/$out_name \
         $BUILD_PREFIX/include/*blas* \
         $BUILD_PREFIX/include/*lapack* \
         $BUILD_PREFIX/lib/libscipy_openblas* \
-        $BUILD_PREFIX/lib/pkgconfig/openblas* \
+        $BUILD_PREFIX/lib/pkgconfig/scipy-openblas* \
         $BUILD_PREFIX/lib/cmake/openblas
 }
 

--- a/tools/build_steps.sh
+++ b/tools/build_steps.sh
@@ -178,6 +178,7 @@ function do_build_lib {
     else
         local version=$(cd OpenBLAS && git describe --tags --abbrev=8)
     fi
+    mv $BUILD_PREFIX/lib/pkgconfig/openblas*.pc $BUILD_PREFIX/lib/pkgconfig/scipy-openblas.pc
     local plat_tag=$(get_plat_tag $plat)
     local suff=""
     [ -n "$suffix" ] && suff="-$suffix"
@@ -186,11 +187,11 @@ function do_build_lib {
         # do it ourselves
         static_libname=$(basename `find OpenBLAS -maxdepth 1 -type f -name '*.a' \! -name '*.dll.a'`)
         renamed_libname=$(basename `find OpenBLAS -maxdepth 1 -type f -name '*.renamed'`)
-        # set -x  # echo commands
         cp -f "OpenBLAS/${renamed_libname}" "$BUILD_PREFIX/lib/${static_libname}"
-        # set +x
+        sed -e "s/^Cflags.*/\0 -DBLAS_SYMBOL_PREFIX=scipy_ -DBLAS_SYMBOL_SUFFIX=64_/" -i.bak $BUILD_PREFIX/lib/pkgconfig/scipy-openblas.pc
+    else
+        sed -e "s/^Cflags.*/\0 -DBLAS_SYMBOL_PREFIX=scipy_/" -i.bak $BUILD_PREFIX/lib/pkgconfig/scipy-openblas.pc
     fi
-    mv $BUILD_PREFIX/lib/pkgconfig/openblas*.pc $BUILD_PREFIX/lib/pkgconfig/scipy-openblas.pc
 
     local out_name="openblas${symbolsuffix}-${version}-${plat_tag}${suff}.tar.gz"
     tar zcvf libs/$out_name \

--- a/tools/build_steps.sh
+++ b/tools/build_steps.sh
@@ -95,6 +95,7 @@ function patch_source {
     # Runs inside OpenBLAS directory
     # Make the patches by git format-patch <old commit>
     for f in $(ls ../patches); do
+        echo applying patch $f
         git apply ../patches/$f
     done 
 }

--- a/tools/build_steps.sh
+++ b/tools/build_steps.sh
@@ -93,8 +93,10 @@ function build_lib {
 
 function patch_source {
     # Runs inside OpenBLAS directory
-    # bash does not like an empty function, add a null statement
-    :
+    # Make the patches by git format-patch <old commit>
+    for f in $(ls ../patches); do
+        git apply ../patches/$f
+    done 
 }
 
 function do_build_lib {

--- a/tools/local_build.sh
+++ b/tools/local_build.sh
@@ -18,7 +18,7 @@ else
     
 fi
 export REPO_DIR=OpenBLAS
-export OPENBLAS_COMMIT="c2f4bdb"
+export OPENBLAS_COMMIT="v0.3.26"
 
 # export MB_ML_LIBC=musllinux
 # export MB_ML_VER=_1_1


### PR DESCRIPTION
Related to numpy/numpy#25505

Instead of building a set of shared objects and creating symlinks to them, create only a single shared object. Use a patch to OpenBLAS.