### PR TITLE
fix pyproject.toml version and add a check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scipy_openblas64"
-version = "0.3.24.95.2"
+version = "0.3.26.0.0"
 requires-python = ">=3.7"
 description = "Provides OpenBLAS for python packaging"
 readme = "README.md"

--- a/tools/build_wheel.sh
+++ b/tools/build_wheel.sh
@@ -22,6 +22,13 @@ tar -C local/scipy_openblas64 --strip-components=2 -xf libs/openblas*.tar.gz
 # do not package the static libs and symlinks, only take the shared object
 find local/scipy_openblas64/lib -maxdepth 1 -type l -delete
 rm local/scipy_openblas64/lib/*.a
+# Check that the pyproject.toml and the pkgconfig versions agree
+py_version=$(grep "^version" pyproject.toml | sed -e "s/version = \"//")
+pkg_version=$(grep "version=" ./local/scipy_openblas64/lib/pkgconfig/openblas64.pc | sed -e "s/version=//")
+if [[ $py_version != $pkg_version* ]]; then
+  echo Version from pyproject.toml "$py_version" does not match version from build "pkg_version"
+  exit 1
+fi
 # Do not package the pkgconfig stuff, use the wheel functionality instead
 rm -rf local/scipy_openblas64/lib/pkgconfig
 

--- a/tools/build_wheel.sh
+++ b/tools/build_wheel.sh
@@ -22,9 +22,13 @@ tar -C local/scipy_openblas64 --strip-components=2 -xf libs/openblas*.tar.gz
 # do not package the static libs and symlinks, only take the shared object
 find local/scipy_openblas64/lib -maxdepth 1 -type l -delete
 rm local/scipy_openblas64/lib/*.a
-# Check that the pyproject.toml and the pkgconfig versions agree
+# Check that the pyproject.toml and the pkgconfig versions agree.
 py_version=$(grep "^version" pyproject.toml | sed -e "s/version = \"//")
-pkg_version=$(grep "version=" ./local/scipy_openblas64/lib/pkgconfig/openblas64.pc | sed -e "s/version=//")
+pkg_version=$(grep "version=" ./local/scipy_openblas64/lib/pkgconfig/scipy-openblas*.pc | sed -e "s/version=//")
+if [[ -z "$pkg_version" ]]; then
+  echo Could not read version from pkgconfig file
+  exit 1
+fi
 if [[ $py_version != $pkg_version* ]]; then
   echo Version from pyproject.toml "$py_version" does not match version from build "pkg_version"
   exit 1


### PR DESCRIPTION
PR #128 updated the OpenBLAS version but did not update the pyproject.toml version. Fix and add a check so this won't happen in the future.