### PR TITLE
tweak build for freebsd 'sed' and wheel version check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scipy_openblas64"
-version = "0.3.26.0.0"
+version = "0.3.26.0"
 requires-python = ">=3.7"
 description = "Provides OpenBLAS for python packaging"
 readme = "README.md"

--- a/tools/build_steps.sh
+++ b/tools/build_steps.sh
@@ -188,9 +188,9 @@ function do_build_lib {
         static_libname=$(basename `find OpenBLAS -maxdepth 1 -type f -name '*.a' \! -name '*.dll.a'`)
         renamed_libname=$(basename `find OpenBLAS -maxdepth 1 -type f -name '*.renamed'`)
         cp -f "OpenBLAS/${renamed_libname}" "$BUILD_PREFIX/lib/${static_libname}"
-        sed -e "s/^Cflags.*/\0 -DBLAS_SYMBOL_PREFIX=scipy_ -DBLAS_SYMBOL_SUFFIX=64_/" -i.bak $BUILD_PREFIX/lib/pkgconfig/scipy-openblas.pc
+        sed -e "s/\(^Cflags.*\)/\1 -DBLAS_SYMBOL_PREFIX=scipy_ -DBLAS_SYMBOL_SUFFIX=64_/" -i.bak $BUILD_PREFIX/lib/pkgconfig/scipy-openblas.pc
     else
-        sed -e "s/^Cflags.*/\0 -DBLAS_SYMBOL_PREFIX=scipy_/" -i.bak $BUILD_PREFIX/lib/pkgconfig/scipy-openblas.pc
+        sed -e "s/\(^Cflags.*\)/\1 -DBLAS_SYMBOL_PREFIX=scipy_/" -i.bak $BUILD_PREFIX/lib/pkgconfig/scipy-openblas.pc
     fi
 
     local out_name="openblas${symbolsuffix}-${version}-${plat_tag}${suff}.tar.gz"

--- a/tools/build_wheel.sh
+++ b/tools/build_wheel.sh
@@ -24,7 +24,7 @@ find local/scipy_openblas64/lib -maxdepth 1 -type l -delete
 rm local/scipy_openblas64/lib/*.a
 # Check that the pyproject.toml and the pkgconfig versions agree.
 py_version=$(grep "^version" pyproject.toml | sed -e "s/version = \"//")
-pkg_version=$(grep "version=" ./local/scipy_openblas64/lib/pkgconfig/scipy-openblas*.pc | sed -e "s/version=//")
+pkg_version=$(grep "version=" ./local/scipy_openblas64/lib/pkgconfig/scipy-openblas*.pc | sed -e "s/version=//" | sed -e "s/dev//")
 if [[ -z "$pkg_version" ]]; then
   echo Could not read version from pkgconfig file
   exit 1


### PR DESCRIPTION
A few problems appeared in the builds:
- macos sed does not have a `\0` output group for the whole match, use a capture group and `\1` instead
- tweak the wheel build version comparison, it choked on a `.dev` suffix`
- no need for a sub-sub version specifier, I did not upload the wheels. Before the upload, both NumPy and SciPy should have a pin so the wheel version update can be done in a controlled fashion.