### PR TITLE
wheel name must be scipy-openblas not scipy_openblas

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -104,7 +104,7 @@ jobs:
         fi
         if [[ "${INTERFACE64}" != "1" ]]; then
             mv local/scipy_openblas64 local/scipy_openblas32
-            # rewrite the name of the project to scipy_openblas32
+            # rewrite the name of the project to scipy-openblas32
             # this is a hack, but apparently there is no other way to change the name
             # of a pyproject.toml project
             sed -e "s/openblas64/openblas32/" -i pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "scipy_openblas64"
-version = "0.3.26.0.2"
+name = "scipy-openblas64"
+version = "0.3.26.0.3"
 requires-python = ">=3.7"
 description = "Provides OpenBLAS for python packaging"
 readme = "README.md"
@@ -21,6 +21,7 @@ classifiers = [
 # ]
 # maintainers = [
 # ]
+license = {file = "LICENSE.txt"}
 
 [project.urls]
 homepage = "https://github.com/MacPython/openblas-libs"

--- a/tools/build_wheel.sh
+++ b/tools/build_wheel.sh
@@ -10,7 +10,7 @@ if [ "$?" != "0" ]; then
     # inside docker
     cd /openblas
 fi
-PYTHON=python3.9
+PYTHON=${PYTHON:-python3.9}
 
 mkdir -p local/openblas
 mkdir -p dist

--- a/tools/local_build.sh
+++ b/tools/local_build.sh
@@ -1,21 +1,27 @@
 # Replicate the workflow from posix.yml locally on posix
 # This may bitrot, compare it to the original file before using
 
+set -e
 
 # Set extra env
-if [ "uname -m" == "x86_64" ]; then
+if [[ $(uname -m) == "x86_64" ]]; then
+    echo got x86_64
     export TRAVIS_OS_NAME=ubuntu-latest
     export PLAT=x86_64
     # export PLAT=i86
     DOCKER_TEST_IMAGE=multibuild/xenial_${PLAT}
+elif [[ $(uname -m) == arm64 ]]; then
+    echo got arm64
+    exit -1
 else
+    echo got nothing
+    exit -1
     export TRAVIS_OS_NAME=osx
     export LDFLAGS="-L/Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/lib"
     export LIBRARY_PATH="-L/Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/lib"
     export PLAT=x86_64
     # export PLAT=arm64
     export SUFFIX=gf_c469a42
-    
 fi
 export REPO_DIR=OpenBLAS
 export OPENBLAS_COMMIT="v0.3.26"
@@ -32,6 +38,9 @@ function install_virtualenv {
 }
 
 function build_openblas {
+    if [[ -z VIRTUAL_ENV ]]; then
+        echo "must be run in a virtualenv"
+    fi
     # Build OpenBLAS
     set -xeo pipefail
     if [ "$PLAT" == "arm64" ]; then
@@ -56,4 +65,4 @@ function build_openblas {
 }
 
 # install_virtualenv
-# build_openblas
+build_openblas

--- a/tools/upload_to_anaconda_staging.sh
+++ b/tools/upload_to_anaconda_staging.sh
@@ -13,12 +13,14 @@ upload_wheels() {
     VERSION=$(git describe --tags --abbrev=8)
     popd
 
+    # if only rename was built-in to bash...
+    for f in dist/*.whl; do cp $f "${f/scipy_openblas/scipy-openblas}"; done
     if [ "$OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN" != "" ]; then
         echo "Uploading OpenBLAS $VERSION to anaconda.org/multibuild-wheels-staging"
 
         anaconda -t $OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN upload \
                 --no-progress --force -u multibuild-wheels-staging \
-                dist/scipy_openblas*.whl
+                dist/scipy-openblas*.whl
 
     fi
     if [ "$ANACONDA_SCIENTIFIC_PYTHON_UPLOAD" == "" ]; then
@@ -28,7 +30,7 @@ upload_wheels() {
 
         anaconda -t $ANACONDA_SCIENTIFIC_PYTHON_UPLOAD upload \
                 --no-progress --force -u scientific-python-nightly-wheels \
-                dist/scipy_openblas*.whl
+                dist/scipy-openblas*.whl
 
         tarballs=$(ls -d builds/openblas*.zip libs/openblas*.tar.gz 2>/dev/null)
         anaconda -t $ANACONDA_SCIENTIFIC_PYTHON_UPLOAD upload \


### PR DESCRIPTION
- [x] I updated the version in pyproject.toml and made sure it matches `git describe --tags --abbrev=8` in OpenBLAS at the `OPENBLAS_COMMIT`

The wheel name to be uploaded to ananconda must have a dash scipy-openblas not scipy_openblas.

Fixes scientific-python/upload-nightly-action#61
