### PR TITLE
FIX: Keep the filenames of verified wheels unchanged

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scipy-openblas64"
-version = "0.3.26.0.4"
+version = "0.3.26.0.5"
 requires-python = ">=3.7"
 description = "Provides OpenBLAS for python packaging"
 readme = "README.md"

--- a/tools/upload_to_anaconda_staging.sh
+++ b/tools/upload_to_anaconda_staging.sh
@@ -13,14 +13,12 @@ upload_wheels() {
     VERSION=$(git describe --tags --abbrev=8)
     popd
 
-    # if only rename was built-in to bash...
-    for f in dist/*.whl; do cp $f "${f/scipy_openblas/scipy-openblas}"; done
     if [ "$OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN" != "" ]; then
         echo "Uploading OpenBLAS $VERSION to anaconda.org/multibuild-wheels-staging"
 
         anaconda -t $OPENBLAS_LIBS_STAGING_UPLOAD_TOKEN upload \
                 --no-progress --force -u multibuild-wheels-staging \
-                dist/scipy-openblas*.whl
+                dist/scipy_openblas*.whl
 
     fi
     if [ "$ANACONDA_SCIENTIFIC_PYTHON_UPLOAD" == "" ]; then
@@ -30,7 +28,7 @@ upload_wheels() {
 
         anaconda -t $ANACONDA_SCIENTIFIC_PYTHON_UPLOAD upload \
                 --no-progress --force -u scientific-python-nightly-wheels \
-                dist/scipy-openblas*.whl
+                dist/scipy_openblas*.whl
 
         tarballs=$(ls -d builds/openblas*.zip libs/openblas*.tar.gz 2>/dev/null)
         anaconda -t $ANACONDA_SCIENTIFIC_PYTHON_UPLOAD upload \


### PR DESCRIPTION
Reverts the portion of PR https://github.com/MacPython/openblas-libs/pull/135 that changes the _**filename**_ of the wheels.

Resolves https://github.com/numpy/numpy/issues/25849

Once a wheel has been created through a build process and its metadata set and verified it should not be altered as this can invalidate the metadata. A package can have a project name that is `-` seperated and a wheel filename that is `_` seperated and still be fine.

- [x] I updated the version in pyproject.toml and made sure it matches `git describe --tags --abbrev=8` in OpenBLAS at the `OPENBLAS_COMMIT`

```console
$ git grep "version =" pyproject.toml
pyproject.toml:version = "0.3.26.0.5"
$ cd OpenBLAS/
$ git describe --tags --abbrev=8
v0.3.26
$
```

c.f. https://github.com/scientific-python/upload-nightly-action/issues/65 for a discussion on why.

(Note that the https://github.com/scientific-python/upload-nightly-action test project used in CI tests uses this convention of project name being `test-project` and wheel filename being `test_package-0.0.1-py3-none-any.whl`.)