### PR TITLE
remove wheel build on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,12 +78,6 @@ install:
 script:
     # Build library and collect into libs subdirectory
     - build_lib "$PLAT" "$INTERFACE64"
-    - libc=${MB_ML_LIBC:-manylinux}
-    - docker_image=quay.io/pypa/${libc}${MB_ML_VER}_${PLAT}
-    - docker run --rm -e INTERFACE64="${INTERFACE64}" \
-        -e MB_ML_LIBC="${MB_ML_LIBC}" \
-        -v $(pwd):/openblas $docker_image \
-        /bin/bash -xe /openblas/tools/build_wheel.sh
 
 after_success:
     - set +ex


### PR DESCRIPTION
This is a PR to build older-style v0.3.26 tarballs and upload them to https://anaconda.org/multibuild-wheels-staging/openblas-libs/
