### PR TITLE
MAINT: build new OpenBLAS for SciPy

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -45,7 +45,7 @@ jobs:
             INTERFACE64: '1'
     env:
       REPO_DIR: OpenBLAS
-      OPENBLAS_COMMIT: "4a6025af9a"
+      OPENBLAS_COMMIT: "b1e8ba5017"
       MACOSX_DEPLOYMENT_TARGET: 10.9
       MB_PYTHON_VERSION: ${{ matrix.python-version }}
       TRAVIS_PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: null
 
 env:
-  OPENBLAS_COMMIT: "4a6025af9a"
+  OPENBLAS_COMMIT: "b1e8ba5017"
   OPENBLAS_ROOT: "c:\\opt"
   # Preserve working directory for calls into bash
   # Without this, invoking bash will cd to the home directory

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
     global:
         # The archive that gets built has name from ``git describe`` on this
         # commit.
-        - OPENBLAS_COMMIT="4a6025af9a"
+        - OPENBLAS_COMMIT="b1e8ba5017"
         - REPO_DIR=OpenBLAS
 
 language: python


### PR DESCRIPTION
Fixes #148

* Note that this PR is against the `scipy` feature branch and not the `main` branch because it is intended to provide new OpenBLAS binaries for SciPy, but in the old non-wheel format (we're not ready for the new wheel format just yet).

* The specific motivation for needing these new OpenBLAS binaries is discussed at this SciPy issue:
https://github.com/scipy/scipy/issues/20294

* In the above issue one of the lead OpenBLAS developers informally suggests it should be "ok" to build off their `develop` branch at this new hash given the merging of https://github.com/OpenMathLib/OpenBLAS/pull/4587 to prevent a Windows hang for `scikit-learn`, as I push forward with the SciPy`1.13.0` release (which is under some pressure from NumPy `2.0.0rc1` release now).