### PR TITLE
travis crashes when log is too large

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scipy-openblas64"
-version = "0.3.27.44.1"
+version = "0.3.27.44.2"
 requires-python = ">=3.7"
 description = "Provides OpenBLAS for python packaging"
 readme = "README.md"

--- a/tools/build_steps.sh
+++ b/tools/build_steps.sh
@@ -170,7 +170,7 @@ function do_build_lib {
     CFLAGS="$CFLAGS -fvisibility=protected -Wno-uninitialized" \
     make BUFFERSIZE=20 DYNAMIC_ARCH=1 \
         USE_OPENMP=0 NUM_THREADS=64 \
-        BINARY=$bitness $interface_flags $target_flags
+        BINARY=$bitness $interface_flags $target_flags > /dev/null
     make PREFIX=$BUILD_PREFIX $interface_flags install
     popd
     stop_spinner


### PR DESCRIPTION
- [x] I updated the version in pyproject.toml and made sure it matches `git describe --tags --abbrev=8` in OpenBLAS at the `OPENBLAS_COMMIT`
