### PR TITLE
fix another place when builds are triggered manually

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -141,8 +141,9 @@ jobs:
 
     - name: Build and test wheel
       run: |
-        if [[ "$NIGHTLY" = "true" ]]; then
+        if [ "$NIGHTLY" = "true"  -a  "$BRANCH_NAME" = "main" ]; then
           # Set the pyproject.toml version: convert v0.3.24-30-g138ed79f to 0.3.34.30
+          # This will fail if `git describe --tags` hits a tag like v0.3.27
           version=$(cd OpenBLAS && git describe --tags --abbrev=8 | sed -e "s/^v\(.*\)-g.*/\1/" | sed -e "s/-/./g")
           sed -e "s/^version = .*/version = \"${version}\"/" -i.bak pyproject.toml
         fi

--- a/tools/upload_to_anaconda_staging.sh
+++ b/tools/upload_to_anaconda_staging.sh
@@ -29,13 +29,5 @@ upload_wheels() {
         anaconda -t $ANACONDA_SCIENTIFIC_PYTHON_UPLOAD upload \
                 --no-progress --force -u scientific-python-nightly-wheels \
                 dist/scipy_openblas*.whl
-
-        tarballs=$(ls -d builds/openblas*.zip libs/openblas*.tar.gz 2>/dev/null)
-        anaconda -t $ANACONDA_SCIENTIFIC_PYTHON_UPLOAD upload \
-                --no-progress --force -u scientific-python-nightly-wheels \
-                -t file -p "openblas-libs" -v "$VERSION" \
-                -d "OpenBLAS for multibuild wheels" \
-                -s "OpenBLAS for multibuild wheels" \
-                ${tarballs}
     fi
 }


### PR DESCRIPTION
- [ ] I updated the version in pyproject.toml and made sure it matches `git describe --tags --abbrev=8` in OpenBLAS at the `OPENBLAS_COMMIT`

Another CI fix when triggering builds manually