### PR TITLE
Use DYNAMIC_LIST to shrink the shared object on x86_64 and i686

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scipy-openblas64"
-version = "0.3.27.44.4"
+version = "0.3.27.44.5"
 requires-python = ">=3.7"
 description = "Provides OpenBLAS for python packaging"
 readme = "README.md"

--- a/tools/build_openblas.sh
+++ b/tools/build_openblas.sh
@@ -64,12 +64,14 @@ if [ "$build_bits" == 64 ]; then
     extra="-fno-asynchronous-unwind-tables"
     vc_arch="X64"
     plat_tag="win_amd64"
+    dynamic_list="PRESCOTT NEHALEM SANDYBRIDGE HASWELL SKYLAKEX"
 else
     march=pentium4
     extra="-mfpmath=sse -msse2"
     fextra="-m32"
     vc_arch="i386"
     plat_tag="win32"
+    dynamic_list="PRESCOTT NEHALEM SANDYBRIDGE HASWELL"
 fi
 cflags="-O2 -march=$march -mtune=generic $extra"
 fflags="$fextra $cflags -frecursive -ffpe-summary=invalid,zero"
@@ -100,8 +102,9 @@ patch -p1 < ../patches-windows/revert-win-threading.patch
 # Build OpenBLAS
 make BINARY=$build_bits DYNAMIC_ARCH=1 USE_THREAD=1 USE_OPENMP=0 \
      NUM_THREADS=24 NO_WARMUP=1 NO_AFFINITY=1 CONSISTENT_FPCSR=1 \
-     BUILD_LAPACK_DEPRECATED=1 TARGET=PRESCOTT BUFFERSIZE=20\
+     BUILD_LAPACK_DEPRECATED=1 TARGET=PRESCOTT BUFFERSIZE=20 \
      LDFLAGS="$LDFLAGS" \
+     DYNAMIC_LIST="$dynamic_list" \
      COMMON_OPT="$cflags" \
      FCOMMON_OPT="$fflags" \
      MAX_STACK_ALLOC=2048 \

--- a/tools/build_steps.sh
+++ b/tools/build_steps.sh
@@ -120,6 +120,7 @@ function do_build_lib {
         Linux-x86_64)
             local bitness=64
             local target_flags="TARGET=PRESCOTT"
+            local dynamic_list="PRESCOTT NEHALEM SANDYBRIDGE HASWELL SKYLAKEX"
             ;;
         Darwin-x86_64)
             local bitness=64
@@ -130,6 +131,7 @@ function do_build_lib {
         *-i686)
             local bitness=32
             local target_flags="TARGET=PRESCOTT"
+            local dynamic_list="PRESCOTT NEHALEM SANDYBRIDGE HASWELL"
             ;;
         Linux-aarch64)
             local bitness=64


### PR DESCRIPTION
- [x] I updated the version in pyproject.toml and made sure it matches `git describe --tags --abbrev=8` in OpenBLAS at the `OPENBLAS_COMMIT`

I did not add a macos-x86_64 alternative, that platform is in maintenance mode as more people move to macos-arm64