### PR TITLE
use 'DYNAMIC_LIST' to shrink x86_64 and i686 wheels (v0.3.28.0.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "scipy-openblas64"
 # v0.3.28
-version = "0.3.28.0.0"
+version = "0.3.28.0.1"
 requires-python = ">=3.7"
 description = "Provides OpenBLAS for python packaging"
 readme = "README.md"

--- a/tools/build_openblas.sh
+++ b/tools/build_openblas.sh
@@ -64,12 +64,14 @@ if [ "$build_bits" == 64 ]; then
     extra="-fno-asynchronous-unwind-tables"
     vc_arch="X64"
     plat_tag="win_amd64"
+    dynamic_list="PRESCOTT NEHALEM SANDYBRIDGE HASWELL SKYLAKEX"
 else
     march=pentium4
     extra="-mfpmath=sse -msse2"
     fextra="-m32"
     vc_arch="i386"
     plat_tag="win32"
+    dynamic_list="PRESCOTT NEHALEM SANDYBRIDGE HASWELL"
 fi
 cflags="-O2 -march=$march -mtune=generic $extra"
 fflags="$fextra $cflags -frecursive -ffpe-summary=invalid,zero"
@@ -99,8 +101,9 @@ patch -p1 < ../patches-windows/openblas-make-libs.patch
 CFLAGS="$CFLAGS -fvisibility=protected -fno-ident" \
 make BINARY=$build_bits DYNAMIC_ARCH=1 USE_THREAD=1 USE_OPENMP=0 \
      NUM_THREADS=24 NO_WARMUP=1 NO_AFFINITY=1 CONSISTENT_FPCSR=1 \
-     BUILD_LAPACK_DEPRECATED=1 TARGET=PRESCOTT BUFFERSIZE=20\
+     BUILD_LAPACK_DEPRECATED=1 TARGET=PRESCOTT BUFFERSIZE=20 \
      LDFLAGS="$LDFLAGS" \
+     DYNAMIC_LIST="$dynamic_list" \
      COMMON_OPT="$cflags" \
      FCOMMON_OPT="$fflags" \
      MAX_STACK_ALLOC=2048 \

--- a/tools/build_steps.sh
+++ b/tools/build_steps.sh
@@ -125,6 +125,7 @@ function do_build_lib {
         Linux-x86_64)
             local bitness=64
             local target_flags="TARGET=PRESCOTT"
+            local dynamic_list="PRESCOTT NEHALEM SANDYBRIDGE HASWELL SKYLAKEX"
             ;;
         Darwin-x86_64)
             local bitness=64
@@ -135,6 +136,7 @@ function do_build_lib {
         *-i686)
             local bitness=32
             local target_flags="TARGET=PRESCOTT"
+            local dynamic_list="PRESCOTT NEHALEM SANDYBRIDGE HASWELL"
             ;;
         Linux-aarch64)
             local bitness=64


### PR DESCRIPTION
- [x] I updated the version in pyproject.toml and made sure it matches `git describe --tags --abbrev=8` in OpenBLAS at the `OPENBLAS_COMMIT`

Shrink the wheels by using fewer kernels on x86_64, i686. Replaces #166. Closes #144. Ignoring macos since the x86_64 CPUs there are about 1% of our downloads, compared to 4% windows and the vast majority being linux.
