### PR TITLE
feat: Bump conda-incubator/setup-miniconda from 3.0.4 to 3.1.0

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -180,9 +180,8 @@ jobs:
         name: openblas-${{ matrix.os }}-${{ matrix.PLAT }}-${{ matrix.INTERFACE64 }}-${{ matrix.MB_ML_LIBC }}-${{ matrix.MB_ML_VER }}
         path: libs/openblas*.tar.gz
 
-    - uses: conda-incubator/setup-miniconda@v3.0.4
+    - uses: conda-incubator/setup-miniconda@v3.1.1
       with:
-        architecture: ${{ env.PLAT == 'aarch64' && 'aarch64' || '' }}
         channels: conda-forge
         channel-priority: true
         activate-environment: upload


### PR DESCRIPTION
- [x] I updated the version in pyproject.toml and made sure it matches `git describe --tags --abbrev=8` in OpenBLAS at the `OPENBLAS_COMMIT`

- https://github.com/conda-incubator/setup-miniconda/pull/387
