### PR TITLE
bump OpenBLAS version to 0.3.29, drop musl=1.1, cleanups

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   REPO_DIR: OpenBLAS
-  OPENBLAS_COMMIT: "v0.3.28"
+  OPENBLAS_COMMIT: "v0.3.29"
   MACOSX_DEPLOYMENT_TARGET: 10.9
 
 jobs:
@@ -39,23 +39,12 @@ jobs:
             PLAT: x86_64
             INTERFACE64: '1'
             MB_ML_LIBC: musllinux
-            MB_ML_VER: _1_1
-          - os: ubuntu-latest
-            PLAT: x86_64
-            INTERFACE64: '0'
-            MB_ML_LIBC: musllinux
-            MB_ML_VER: _1_1
-          - os: ubuntu-latest
-            PLAT: x86_64
-            INTERFACE64: '1'
-            MB_ML_LIBC: musllinux
             MB_ML_VER: _1_2
           - os: ubuntu-latest
             PLAT: x86_64
             INTERFACE64: '0'
             MB_ML_LIBC: musllinux
             MB_ML_VER: _1_2
-
 
           - os: ubuntu-24.04-arm
             PLAT: aarch64
@@ -65,16 +54,6 @@ jobs:
             PLAT: aarch64
             INTERFACE64: '1'
             MB_ML_VER: '2014'
-          - os: ubuntu-24.04-arm
-            PLAT: aarch64
-            INTERFACE64: '0'
-            MB_ML_LIBC: musllinux
-            MB_ML_VER: _1_1
-          - os: ubuntu-24.04-arm
-            PLAT: aarch64
-            INTERFACE64: '1'
-            MB_ML_LIBC: musllinux
-            MB_ML_VER: _1_1
           - os: ubuntu-24.04-arm
             PLAT: aarch64
             INTERFACE64: '0'
@@ -194,7 +173,6 @@ jobs:
       env:
        ANACONDA_SCIENTIFIC_PYTHON_UPLOAD: ${{ secrets.ANACONDA_SCIENTIFIC_PYTHON_UPLOAD }}
       run: |
-        # Pin urllib3<2 due to github.com/Anaconda-Platform/anaconda-client/issues/654
-        conda install -y anaconda-client 'urllib3<2.0.0'
+        conda install -y anaconda-client
         source tools/upload_to_anaconda_staging.sh
         upload_wheels

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: null
 
 env:
-  OPENBLAS_COMMIT: "v0.3.28"
+  OPENBLAS_COMMIT: "v0.3.29"
   OPENBLAS_ROOT: "c:\\opt"
   # Preserve working directory for calls into bash
   # Without this, invoking bash will cd to the home directory
@@ -161,9 +161,12 @@ jobs:
         python -m scipy_openblas32
         python -c "import scipy_openblas32; print(scipy_openblas32.get_pkg_config())"
 
-    - uses: conda-incubator/setup-miniconda@v3.0.1
+    - uses: conda-incubator/setup-miniconda@v3.1.1
       with:
+        channels: conda-forge
+        channel-priority: true
         activate-environment: upload
+        miniforge-version: latest
 
     - name: Upload
       # see https://github.com/marketplace/actions/setup-miniconda for why
@@ -172,7 +175,6 @@ jobs:
       env:
        ANACONDA_SCIENTIFIC_PYTHON_UPLOAD: ${{ secrets.ANACONDA_SCIENTIFIC_PYTHON_UPLOAD }}
       run: |
-        # Pin urllib3<2 due to github.com/Anaconda-Platform/anaconda-client/issues/654
-        conda install -y anaconda-client 'urllib3<2.0.0'
+        conda install -y anaconda-client
         source tools/upload_to_anaconda_staging.sh
         upload_wheels

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
     global:
         # The archive that gets built has name from ``git describe`` on this
         # commit.
-        - OPENBLAS_COMMIT: "v0.3.28"
+        - OPENBLAS_COMMIT: "v0.3.29"
         - REPO_DIR=OpenBLAS
 
 sudo: required
@@ -11,36 +11,6 @@ services: docker
 
 matrix:
   include:
-    - os: linux
-      arch: arm64
-      env:
-        - PLAT=aarch64
-        - MB_ML_VER=_1_1
-        - INTERFACE64=0
-        - MB_ML_LIBC=musllinux
-        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
-    - os: linux
-      arch: arm64
-      env:
-        - PLAT=aarch64
-        - INTERFACE64=1
-        - MB_ML_VER=_1_1
-        - MB_ML_LIBC=musllinux
-        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
-    - os: linux
-      arch: arm64
-      env:
-        - PLAT=aarch64
-        - MB_ML_VER=2014
-        - INTERFACE64=0
-        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
-    - os: linux
-      arch: arm64
-      env:
-        - PLAT=aarch64
-        - INTERFACE64=1
-        - MB_ML_VER=2014
-        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
     - os: linux
       arch: s390x
       env:
@@ -93,7 +63,7 @@ script:
 after_success:
     - set +ex
     - sudo chmod -R a+w /home/travis/.cache
-    - pip install -q git+https://github.com/Anaconda-Platform/anaconda-client@1.8.0
+    - pip install -q git+https://github.com/Anaconda-Platform/anaconda-client@1.13.0
     # Upload libraries to the shared staging area on anaconda.org
     - sudo chmod -R a+w dist
     - source tools/upload_to_anaconda_staging.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scipy-openblas64"
-# v0.3.28
-version = "0.3.28.0.2"
+# v0.3.29
+version = "0.3.29.0.0"
 requires-python = ">=3.7"
 description = "Provides OpenBLAS for python packaging"
 readme = "README.md"
@@ -26,7 +26,7 @@ license = {file = "LICENSE.txt"}
 
 [project.urls]
 homepage = "https://github.com/MacPython/openblas-libs"
-upstream = "https://github.com/xianyi/OpenBLAS"
+upstream = "https://github.com/OpenMathLib/OpenBLAS"
 
 [tool.setuptools.packages.find]
 # scanning for namespace packages is true by default in pyproject.toml, so


### PR DESCRIPTION
- [x] I updated the version in pyproject.toml and made sure it matches `git describe --tags --abbrev=8` in OpenBLAS at the `OPENBLAS_COMMIT`

- Closes #185, updates OpenBLAS to 0.3.29
- remove aarch64 builds from travis
- remove musllinux 1.1 builds, it is EOL
- update anaconda-client usage
- apply #187 to windows as well