### PR TITLE
Skip extra linker flags on Windows ARM64 in get_pkg_config()

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,1 @@
-- [ ] I updated the version in pyproject.toml and made sure it matches `git describe --tags --abbrev=8` in OpenBLAS at the `OPENBLAS_COMMIT`
+- [ ] I updated the package version in pyproject.toml and made sure the first 3 numbers match `git describe --tags --abbrev=8` in OpenBLAS at the `OPENBLAS_COMMIT`. If I did not update `OPENBLAS_COMMIT`, I incremented the wheel build number (i.e. 0.3.29.0.0 to 0.3.29.0.1)

--- a/local/scipy_openblas64/__init__.py
+++ b/local/scipy_openblas64/__init__.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 import sys
 from textwrap import dedent
-
+import platform
 
 _HERE = Path(__file__).resolve().parent
 
@@ -68,8 +68,11 @@ def get_pkg_config(use_preloading=False):
     ``f"-L{get_library()}" so that at runtime this module must be imported before
     the target module
     """
+    machine = platform.machine().lower()
+    extralib = ""
     if sys.platform == "win32":
-        extralib = "-defaultlib:advapi32 -lgfortran -lquadmath"
+        if machine != "arm64":
+            extralib = "-defaultlib:advapi32 -lgfortran -lquadmath"
         libs_flags = f"-L${{libdir}} -l{get_library()}"
     else:
         extralib = f"-lm -lpthread -lgfortran -lquadmath -L${{libdir}} -l{get_library()}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "scipy-openblas64"
 # v0.3.29
-version = "0.3.29.265.0"
+version = "0.3.29.265.1"
 requires-python = ">=3.7"
 description = "Provides OpenBLAS for python packaging"
 readme = "README.md"


### PR DESCRIPTION
Hi @mattip and @matthew-brett ,

- Upon setting up CI environment for building SciPy on WoA using the current [scipy_openblas32](https://files.pythonhosted.org/packages/54/c3/b1d9ab04b142fee8c06d609d6a2a9c99396c161091d37bc15aff932c4cbd/scipy_openblas32-0.3.29.265.0-py3-none-win_arm64.whl) wheel, the build fails due to missing include libraries as seen in this [log](https://github.com/Mugundanmcw/scipy_for_woa/actions/runs/15420591446/job/43394363168).

- The root cause is due to the inclusion of extra linker flags (-lgfortran -lquadmath), which are only required for GNU-based compilers which are not required for WoA as it uses LLVM toolchain.

- To fix this, the get_pkg_config() function in the init.py is updated to skip extra include directories when the architecture is Windows ARM64 which ensures clean builds on WoA without affecting x64 builds.

- [x] I updated the version in pyproject.toml and made sure it matches `git describe --tags --abbrev=8` in OpenBLAS at the `OPENBLAS_COMMIT`
