### PR TITLE
use trapping-math with clang

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -23,16 +23,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
         PLAT: [i686, x86_64]
         INTERFACE64: ['0', '1']
         MB_ML_VER: ['2014']
         MB_ML_LIBC: ['manylinux']
         include:
-          - os: macos-latest
+          - os: macos-13
             PLAT: arm64
             INTERFACE64: '1'
-          - os: macos-latest
+          - os: macos-13
             PLAT: arm64
             INTERFACE64: '0'
           - os: ubuntu-latest
@@ -67,7 +67,7 @@ jobs:
 
         exclude:
           - PLAT: i686
-            os: macos-latest
+            os: macos-13
           - PLAT: i686
             INTERFACE64: '1'
     env:
@@ -94,9 +94,9 @@ jobs:
         echo "DOCKER_TEST_IMAGE=$(echo multibuild/xenial_${{ matrix.PLAT}})" >> $GITHUB_ENV;
 
     - uses: maxim-lobanov/setup-xcode@v1.6.0
-      if: ${{ matrix.os == 'macos-latest' }}
+      if: ${{ matrix.os == 'macos-13' }}
       with:
-        xcode-version: '15.4'
+        xcode-version: '14.3'
 
     - name: Print some Environment variable
       run: |
@@ -137,7 +137,7 @@ jobs:
           version=$(cd OpenBLAS && git describe --tags --abbrev=8 | sed -e "s/^v\(.*\)-g.*/\1/" | sed -e "s/-/./g")
           sed -e "s/^version = .*/version = \"${version}\"/" -i.bak pyproject.toml
         fi
-        if [ "macos-latest" == "${{ matrix.os }}" ]; then
+        if [ "macos-13" == "${{ matrix.os }}" ]; then
           source tools/build_wheel.sh
         else
           libc=${MB_ML_LIBC:-manylinux}

--- a/tools/local_build.sh
+++ b/tools/local_build.sh
@@ -65,8 +65,8 @@ function build_openblas {
     # Build OpenBLAS
     set -xeo pipefail
     if [ "$PLAT" == "arm64" ]; then
-      sudo xcode-select -switch /Applications/Xcode_15.4.0.app
-      export SDKROOT=/Applications/Xcode_15.4.0-app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk
+      sudo xcode-select -switch /Applications/Xcode_12.5.1.app
+      export SDKROOT=/Applications/Xcode_12.5.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk
       clang --version
     fi
     source tools/build_steps.sh


### PR DESCRIPTION
- [X] I updated the package version in pyproject.toml and made sure the first 3 numbers match `git describe --tags --abbrev=8` in OpenBLAS at the `OPENBLAS_COMMIT`. If I did not update `OPENBLAS_COMMIT`, I incremented the wheel build number (i.e. 0.3.29.0.0 to 0.3.29.0.1)
- Use -ftrapping-math when building on macos-arm64 with clang to prevent spurious floating point errors
- ~Use macos-latest CI image.~
