### PR TITLE
disallow BFLOAT16 kernels on linux-aarch64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "scipy-openblas64"
 # v0.3.30
-version = "0.3.30.0.2"
+version = "0.3.30.0.3"
 requires-python = ">=3.7"
 description = "Provides OpenBLAS for python packaging"
 readme = "README.md"

--- a/tools/build_steps.sh
+++ b/tools/build_steps.sh
@@ -176,6 +176,7 @@ function do_build_lib {
         Linux-aarch64)
             local bitness=64
             local target="ARMV8"
+            CFLAGS="$CFLAGS -DBUILD_BFLOAT16=0"
             ;;
         Darwin-arm64)
             local bitness=64


### PR DESCRIPTION
- [x] I updated the package version in pyproject.toml and made sure the first 3 numbers match `git describe --tags --abbrev=8` in OpenBLAS at the `OPENBLAS_COMMIT`. If I did not update `OPENBLAS_COMMIT`, I incremented the wheel build number (i.e. 0.3.29.0.0 to 0.3.29.0.1)

Motivated by the failed tests on `develop`, see https://github.com/OpenMathLib/OpenBLAS/pull/5399#issuecomment-3149304875
