### PR TITLE
Using USE_THREADS & NUM_THREADS while building openblas for win arm64

### DIFF
--- a/tools/build_steps_win_arm64.bat
+++ b/tools/build_steps_win_arm64.bat
@@ -93,6 +93,9 @@ echo Setting up ARM64 Developer Command Prompt and running CMake...
 :: Initialize VS ARM64 environment
 for /f "usebackq tokens=*" %%i in (`"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do call "%%i\VC\Auxiliary\Build\vcvarsall.bat" arm64
  
+:: Prefer LLVM flang
+PATH=C:\Program Files\LLVM\bin;%PATH%
+
 :: Run CMake and Ninja build
 cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DUSE_THREADS=1 -DNUM_THREADS=24 -DTARGET=ARMV8 -DBUILD_SHARED_LIBS=ON -DARCH=arm64 ^
 -DBINARY=%build_bits% -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_C_COMPILER=clang-cl ^


### PR DESCRIPTION
I have observed that when I install NumPy using pip install numpy and run a np.dot() workload, it only utilizes 4 cores (4 threads), even though my Windows on ARM64 device has 12 cores.

I suspect that since we are not using NUM_THREADS while building for ARM64 in this script, it ends up using the number of cores available on the build machine as the value for NUM_THREADS.