### PR TITLE
patch to remove OpenBLAS PR 4741, cleanup unused bash code

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -59,10 +59,6 @@ jobs:
         submodules: recursive
         fetch-depth: 0
 
-    - name: Set extra env
-      run: |
-        echo "DOCKER_TEST_IMAGE=$(echo multibuild/xenial_${{ matrix.PLAT}})" >> $GITHUB_ENV;
-
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       if: ${{ contains(matrix.os, 'macos') }}
       with:
@@ -71,7 +67,6 @@ jobs:
     - name: Print some Environment variable
       run: |
         echo "PLAT: ${PLAT}"
-        echo "DOCKER_TEST_IMAGE: ${DOCKER_TEST_IMAGE}"
 
     # - name: Setup tmate session
     #   if: ${{ failure() }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,28 +16,24 @@ jobs:
         - PLAT=s390x
         - MB_ML_VER=2014
         - INTERFACE64=0
-        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
     - os: linux
       arch: s390x
       env:
         - PLAT=s390x
         - INTERFACE64=1
         - MB_ML_VER=2014
-        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
     - os: linux
       arch: ppc64le
       env:
         - PLAT=ppc64le
         - MB_ML_VER=2014
         - INTERFACE64=0
-        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
     - os: linux
       arch: ppc64le
       env:
         - PLAT=ppc64le
         - INTERFACE64=1
         - MB_ML_VER=2014
-        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
 
 before_install:
     - source tools/build_steps.sh

--- a/build-openblas.sh
+++ b/build-openblas.sh
@@ -47,24 +47,6 @@ source tools/build_steps.sh
 echo "------ BEFORE BUILD ---------"
 before_build
 
-function fill_submodule {
-    # Restores .git directory to submodule, if necessary
-    # See:
-    # https://stackoverflow.com/questions/41776331/is-there-a-way-to-reconstruct-a-git-directory-for-a-submodule
-    local repo_dir="$1"
-    [ -z "$repo_dir" ] && echo "repo_dir not defined" && exit 1
-    local git_loc="$repo_dir/.git"
-    # For ordinary submodule, .git is a file.
-    [ -d "$git_loc" ] && return
-    # Need to recreate .git directory for submodule
-    local origin_url=$(cd "$repo_dir" && git config --get remote.origin.url)
-    local repo_copy="$repo_dir-$RANDOM"
-    git clone --recursive "$repo_dir" "$repo_copy"
-    rm -rf "$repo_dir"
-    mv "${repo_copy}" "$repo_dir"
-    (cd "$repo_dir" && git remote set-url origin $origin_url)
-}
-
 function clean_code {
     local repo_dir=${1:-$REPO_DIR}
     local build_commit=${2:-$BUILD_COMMIT}
@@ -74,7 +56,6 @@ function clean_code {
     # have a .git directory. If $repo_dir is copied around, tools like
     # Versioneer which require that it be a git repository are unable
     # to determine the version.  Give submodule proper git directory
-    fill_submodule "$repo_dir"
     (cd $repo_dir \
         && git fetch origin --tags \
         && git checkout $build_commit \

--- a/patches/0001-backout-PR-4741.patch
+++ b/patches/0001-backout-PR-4741.patch
@@ -1,0 +1,61 @@
+From fe2f02876134dcfdd75860c622226b6913eef93e Mon Sep 17 00:00:00 2001
+From: mattip <matti.picus@gmail.com>
+Date: Wed, 22 Oct 2025 14:40:01 +0300
+Subject: [PATCH] backout PR 4741
+
+---
+ driver/level3/level3_thread.c | 24 ++++++++++++------------
+ 1 file changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/driver/level3/level3_thread.c b/driver/level3/level3_thread.c
+index 22f27975b..0832db58b 100644
+--- a/driver/level3/level3_thread.c
++++ b/driver/level3/level3_thread.c
+@@ -588,8 +588,8 @@ static int gemm_driver(blas_arg_t *args, BLASLONG *range_m, BLASLONG
+   InitializeCriticalSection((PCRITICAL_SECTION)&level3_lock);
+ #else
+   static pthread_mutex_t  level3_lock    = PTHREAD_MUTEX_INITIALIZER;
+-  static pthread_cond_t  level3_wakeup    = PTHREAD_COND_INITIALIZER;
+-  volatile static BLASLONG CPU_AVAILABLE = MAX_CPU_NUMBER;
++  // static pthread_cond_t  level3_wakeup    = PTHREAD_COND_INITIALIZER;
++  // volatile static BLASLONG CPU_AVAILABLE = MAX_CPU_NUMBER;
+ #endif
+ 
+   blas_arg_t newarg;
+@@ -659,12 +659,12 @@ static int gemm_driver(blas_arg_t *args, BLASLONG *range_m, BLASLONG
+   EnterCriticalSection((PCRITICAL_SECTION)&level3_lock);
+ #else
+   pthread_mutex_lock(&level3_lock);
+-  while(CPU_AVAILABLE < nthreads) { 
+-    pthread_cond_wait(&level3_wakeup, &level3_lock);
+-  } 
+-  CPU_AVAILABLE -= nthreads;
+-  WMB;
+-  pthread_mutex_unlock(&level3_lock);
++  // while(CPU_AVAILABLE < nthreads) {
++  //   pthread_cond_wait(&level3_wakeup, &level3_lock);
++  // }
++  // CPU_AVAILABLE -= nthreads;
++  // WMB;
++  // pthread_mutex_unlock(&level3_lock);
+ #endif
+ 
+ #ifdef USE_ALLOC_HEAP
+@@ -816,10 +816,10 @@ static int gemm_driver(blas_arg_t *args, BLASLONG *range_m, BLASLONG
+ #elif defined(OS_WINDOWS)
+   LeaveCriticalSection((PCRITICAL_SECTION)&level3_lock);
+ #else
+-  pthread_mutex_lock(&level3_lock);
+-  CPU_AVAILABLE += nthreads;
+-  WMB;
+-  pthread_cond_signal(&level3_wakeup);
++  // pthread_mutex_lock(&level3_lock);
++  // CPU_AVAILABLE += nthreads;
++  // WMB;
++  // pthread_cond_signal(&level3_wakeup);
+   pthread_mutex_unlock(&level3_lock);
+ #endif
+ 
+-- 
+2.43.0
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "scipy-openblas64"
 # v0.3.30
-version = "0.3.30.0.3"
+version = "0.3.30.0.4"
 requires-python = ">=3.7"
 description = "Provides OpenBLAS for python packaging"
 readme = "README.md"

--- a/tools/build_steps.sh
+++ b/tools/build_steps.sh
@@ -1,5 +1,5 @@
 # Build script for manylinux and OSX
-BUILD_PREFIX=/usr/local
+BUILD_PREFIX=${BUILD_PREFIX:-/usr/local}
 
 ROOT_DIR=$(dirname $(dirname "${BASH_SOURCE[0]}"))
 

--- a/tools/local_build.sh
+++ b/tools/local_build.sh
@@ -9,17 +9,14 @@ if [[ $(uname) == "Darwin" ]]; then
     export PLAT=x86_64
 elif [[ $(uname -m) == "x86_64" ]]; then
     echo got x86_64
-    export TRAVIS_OS_NAME=ubuntu-latest
     export PLAT=x86_64
     # export PLAT=i86
-    DOCKER_TEST_IMAGE=multibuild/xenial_${PLAT}
 elif [[ $(uname -m) == arm64 ]]; then
     echo got arm64
     exit -1
 else
     echo got nothing
     exit -1
-    export TRAVIS_OS_NAME=osx
     export LDFLAGS="-L/Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/lib"
     export LIBRARY_PATH="-L/Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/lib"
     export PLAT=x86_64
@@ -27,61 +24,13 @@ else
     export SUFFIX=gf_c469a42
 fi
 export REPO_DIR=OpenBLAS
-export OPENBLAS_COMMIT="v0.3.30"
+export OPENBLAS_COMMIT="develop"
 
 # export MB_ML_LIBC=musllinux
-# export MB_ML_VER=_1_1
+# export MB_ML_VER=_1_2
 # export MB_ML_VER=2014
 export INTERFACE64=1
+# export BUILD_PREFIX=/tmp/openblas
+# mkdir -p $BUILD_PREFIX
 
-function install_virtualenv {
-    # Install VirtualEnv
-    python3 -m pip install --upgrade pip
-    pip install virtualenv
-}
-
-function clean_code_local {
-    # Copied from common_utils.sh, with added debugging
-    local repo_dir=${1:-$REPO_DIR}
-    local build_commit=${2:-$BUILD_COMMIT}
-    [ -z "$repo_dir" ] && echo "repo_dir not defined" && exit 1
-    [ -z "$build_commit" ] && echo "build_commit not defined" && exit 1
-    # The package $repo_dir may be a submodule. git submodules do not
-    # have a .git directory. If $repo_dir is copied around, tools like
-    # Versioneer which require that it be a git repository are unable
-    # to determine the version.  Give submodule proper git directory
-    # XXX no need to do this
-    # fill_submodule "$repo_dir"
-    pushd $repo_dir
-    git fetch origin --tags
-    git checkout $build_commit
-    git clean -fxd 
-    git reset --hard
-    git submodule update --init --recursive
-    popd
-}
-
-function build_openblas {
-    if [[ -z VIRTUAL_ENV ]]; then
-        echo "must be run in a virtualenv"
-    fi
-    # Build OpenBLAS
-    set -xeo pipefail
-    source tools/build_steps.sh
-    echo "------ BEFORE BUILD ---------"
-    before_build
-    if [[ "$NIGHTLY" = "true" ]]; then
-      echo "------ CLEAN CODE --------"
-      clean_code $REPO_DIR develop
-      echo "------ BUILD LIB --------"
-      build_lib "$PLAT" "$INTERFACE64" "1"
-    else
-      echo "------ CLEAN CODE --------"
-      clean_code $REPO_DIR $OPENBLAS_COMMIT
-      echo "------ BUILD LIB --------"
-      build_lib "$PLAT" "$INTERFACE64" "0"
-    fi
-}
-
-# install_virtualenv
-build_openblas
+bash ./build-openblas.sh


### PR DESCRIPTION
- [x] I updated the package version in pyproject.toml and made sure the first 3 numbers match `git describe --tags --abbrev=8` in OpenBLAS at the `OPENBLAS_COMMIT`. If I did not update `OPENBLAS_COMMIT`, I incremented the wheel build number (i.e. 0.3.29.0.0 to 0.3.29.0.1)

xref numpy/numpy#29391 which shows the problem and the discussion at https://github.com/OpenMathLib/OpenBLAS/pull/4741#issuecomment-3431940020

This patch may not be needed on some future version of OpenBLAS