### PR TITLE
cleanup clean_code, remove repo_dir, checkout OpenBLAS commit in ci-before-build.sh

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -10,7 +10,6 @@ on:
     - cron: '0 0 * * 0'
 
 env:
-  REPO_DIR: OpenBLAS
   OPENBLAS_COMMIT: "v0.3.30"
   MACOSX_DEPLOYMENT_TARGET: 10.9
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ env:
         # The archive that gets built has name from ``git describe`` on this
         # commit.
         - OPENBLAS_COMMIT: "v0.3.30"
-        - REPO_DIR=OpenBLAS
 
 dist: jammy
 services: docker
@@ -43,9 +42,9 @@ install:
     # Maybe get and clean and patch source
     - |
       if [ ${TRAVIS_EVENT_TYPE} == "cron" ]; then
-        clean_code_local $REPO_DIR develop
+        clean_code develop
       else
-        clean_code_local $REPO_DIR $OPENBLAS_COMMIT
+        clean_code $OPENBLAS_COMMIT
       fi
       echo done install step
 

--- a/build-openblas.sh
+++ b/build-openblas.sh
@@ -47,32 +47,14 @@ source tools/build_steps.sh
 echo "------ BEFORE BUILD ---------"
 before_build
 
-function clean_code {
-    local repo_dir=${1:-$REPO_DIR}
-    local build_commit=${2:-$BUILD_COMMIT}
-    [ -z "$repo_dir" ] && echo "repo_dir not defined" && exit 1
-    [ -z "$build_commit" ] && echo "build_commit not defined" && exit 1
-    # The package $repo_dir may be a submodule. git submodules do not
-    # have a .git directory. If $repo_dir is copied around, tools like
-    # Versioneer which require that it be a git repository are unable
-    # to determine the version.  Give submodule proper git directory
-    (cd $repo_dir \
-        && git fetch origin --tags \
-        && git checkout $build_commit \
-        && git clean -fxd \
-        && git reset --hard \
-        && git submodule update --init --recursive)
-}
-
-
 if [[ "$NIGHTLY" = "true" ]]; then
     echo "------ CLEAN CODE --------"
-    clean_code $REPO_DIR develop
+    clean_code develop
     echo "------ BUILD LIB --------"
     build_lib "$PLAT" "$INTERFACE64" "1"
 else
     echo "------ CLEAN CODE --------"
-    clean_code $REPO_DIR $OPENBLAS_COMMIT
+    clean_code $OPENBLAS_COMMIT
     echo "------ BUILD LIB --------"
     build_lib "$PLAT" "$INTERFACE64" "0"
 fi

--- a/ci-before-build.sh
+++ b/ci-before-build.sh
@@ -47,8 +47,11 @@
 set -xe
 
 if [[ "$NIGHTLY" = "true" ]]; then
+    pushd OpenBLAS
+    git checkout develop
     # Set the pyproject.toml version: convert v0.3.24-30-g138ed79f to 0.3.34.30
-    version=$(cd OpenBLAS && git describe --tags --abbrev=8 | sed -e "s/^v\(.*\)-g.*/\1/" | sed -e "s/-/./g")
+    version=$(git describe --tags --abbrev=8 | sed -e "s/^v\(.*\)-g.*/\1/" | sed -e "s/-/./g")
+    popd
     sed -e "s/^version = .*/version = \"${version}\"/" -i.bak pyproject.toml
 fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "scipy-openblas64"
 # v0.3.30
-version = "0.3.30.0.4"
+version = "0.3.30.0.5"
 requires-python = ">=3.7"
 description = "Provides OpenBLAS for python packaging"
 readme = "README.md"
@@ -45,7 +45,6 @@ before-build = "bash ci-before-build.sh"
 repair-wheel-command = "bash ci-repair-wheel.sh {dest_dir} {wheel}"
 test-command = "cd {package} && bash ci-test.sh "
 environment-pass = [
-  "REPO_DIR",
   "OPENBLAS_COMMIT",
   "MACOSX_DEPLOYMENT_TARGET",
   "NIGHTLY",

--- a/tools/build_steps.sh
+++ b/tools/build_steps.sh
@@ -48,23 +48,18 @@ function before_build {
     fi
 }
 
-function clean_code_local {
+function clean_code {
     set -ex
     # Copied from common_utils.sh, with added debugging
-    local repo_dir=${1:-$REPO_DIR}
-    local build_commit=${2:-$BUILD_COMMIT}
-    [ -z "$repo_dir" ] && echo "repo_dir not defined" && exit 1
+    local build_commit=$1
     [ -z "$build_commit" ] && echo "build_commit not defined" && exit 1
-    pushd $repo_dir
-    echo in $repo_dir
+    pushd OpenBLAS
     git fetch origin --tags
     echo after git fetch origin
     git checkout $build_commit
     echo after git checkout $build_commit
     git clean -fxd 
     echo after git clean
-    git reset --hard
-    echo after git reset
     git submodule update --init --recursive
     echo after git submodule update
     popd

--- a/tools/local_build.sh
+++ b/tools/local_build.sh
@@ -23,14 +23,14 @@ else
     # export PLAT=arm64
     export SUFFIX=gf_c469a42
 fi
-export REPO_DIR=OpenBLAS
-export OPENBLAS_COMMIT="develop"
+export OPENBLAS_COMMIT="v0.3.30"
 
 # export MB_ML_LIBC=musllinux
 # export MB_ML_VER=_1_2
 # export MB_ML_VER=2014
 export INTERFACE64=1
-# export BUILD_PREFIX=/tmp/openblas
-# mkdir -p $BUILD_PREFIX
+export BUILD_PREFIX=/tmp/openblas
+mkdir -p $BUILD_PREFIX
 
-bash ./build-openblas.sh
+ROOT_DIR=$(dirname $(dirname $0))
+bash ${ROOT_DIR}/build-openblas.sh


### PR DESCRIPTION
- [x] I updated the package version in pyproject.toml and made sure the first 3 numbers match `git describe --tags --abbrev=8` in OpenBLAS at the `OPENBLAS_COMMIT`. If I did not update `OPENBLAS_COMMIT`, I incremented the wheel build number (i.e. 0.3.29.0.0 to 0.3.29.0.1)
