### PR TITLE
patch out extraneous lock/unlock

### DIFF
--- a/patches/remove-lock-around-thread-shutdown.patch
+++ b/patches/remove-lock-around-thread-shutdown.patch
@@ -1,0 +1,35 @@
+From ef6f97624ba9a560f64e470ec339f469865fac33 Mon Sep 17 00:00:00 2001
+From: Martin Kroeker <martin@ruby.chemie.uni-freiburg.de>
+Date: Thu, 30 Oct 2025 11:12:47 -0700
+Subject: [PATCH 5/6] [WIP,Testing] remove the lock around the thread shutdown
+ function again (#5479)
+
+* remove the lock around the thread shutdown function - server is locked already here
+---
+ driver/others/blas_server.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/driver/others/blas_server.c b/driver/others/blas_server.c
+index 3d89803a6..4a3182354 100644
+--- a/driver/others/blas_server.c
++++ b/driver/others/blas_server.c
+@@ -984,8 +984,6 @@ int BLASFUNC(blas_thread_shutdown)(void){
+ 
+   int i;
+ 
+-  LOCK_COMMAND(&server_lock);
+-
+   //Free buffers allocated for threads
+   for(i=0; i<MAX_CPU_NUMBER; i++){
+     if(blas_thread_buffer[i]!=NULL){
+@@ -1025,7 +1023,6 @@ int BLASFUNC(blas_thread_shutdown)(void){
+     blas_server_avail = 0;
+ 
+   }
+-  UNLOCK_COMMAND(&server_lock);
+ 
+   return 0;
+ }
+-- 
+2.43.0
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "scipy-openblas64"
 # v0.3.30
-version = "0.3.30.0.6"
+version = "0.3.30.0.7"
 requires-python = ">=3.7"
 description = "Provides OpenBLAS for python packaging"
 readme = "README.md"


### PR DESCRIPTION
- [x] I updated the package version in pyproject.toml and made sure the first 3 numbers match `git describe --tags --abbrev=8` in OpenBLAS at the `OPENBLAS_COMMIT`. If I did not update `OPENBLAS_COMMIT`, I incremented the wheel build number (i.e. 0.3.29.0.0 to 0.3.29.0.1)


Fixes https://github.com/numpy/numpy/issues/5520 and maybe https://github.com/scipy/scipy/issues/23686 without changing the OpenBLAS version (#227 also includes the patch, since it updates OpenBLAS to latest HEAD).