### PR TITLE
use gfortran-15 via FC environment variable on macos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "scipy-openblas64"
 # v0.3.30-349-gf6df9beb
-version = "0.3.30.349.0"
+version = "0.3.30.349.1"
 requires-python = ">=3.7"
 description = "Provides OpenBLAS for python packaging"
 readme = "README.md"

--- a/tools/build_steps.sh
+++ b/tools/build_steps.sh
@@ -39,7 +39,7 @@ function before_build {
         # get_macpython_environment ${MB_PYTHON_VERSION} venv
         python3.9 -m venv venv
         source venv/bin/activate
-        alias gfortran=gfortran-15
+        export FC=gfortran-15
         # Deployment target set by gfortran_utils
         echo "Deployment target $MACOSX_DEPLOYMENT_TARGET"
 


### PR DESCRIPTION
- [x] I updated the package version in pyproject.toml and made sure the first 3 numbers match `git describe --tags --abbrev=8` in OpenBLAS at the `OPENBLAS_COMMIT`. If I did not update `OPENBLAS_COMMIT`, I incremented the wheel build number (i.e. 0.3.29.0.0 to 0.3.29.0.1)


The `alias gfortran=gfortran-15` did not work, as seen in the line `OpenBLAS: Detecting fortran compiler failed. Can only compile BLAS and f2c-converted LAPACK` hidden deep in the logs. I think this is because the alias does not pass command line arguments.