### PR TITLE
fix typo which created bad pkgconfig file on arm64 32-bit interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "scipy-openblas64"
 # v0.3.30-443-g52ec7faf
-version = "0.3.30.443.0"
+version = "0.3.30.443.1"
 requires-python = ">=3.7"
 description = "Provides OpenBLAS for python packaging"
 readme = "README.md"

--- a/tools/build_steps_win_arm64.bat
+++ b/tools/build_steps_win_arm64.bat
@@ -128,7 +128,7 @@ if "%if_bits%"=="32" (
     powershell -Command "(Get-Content 'scipy_openblas32\__main__.py') -replace 'openblas64', 'openblas32' | Out-File 'scipy_openblas32\__main__.py' -Encoding utf8"
     powershell -Command "(Get-Content 'scipy_openblas32\__init__.py') -replace 'openblas64', 'openblas32' | Out-File 'scipy_openblas32\__init__.py' -Encoding utf8"
     powershell -Command "(Get-Content 'scipy_openblas32\__init__.py') -replace 'openblas_get_config64_', 'openblas_get_config' | Out-File 'scipy_openblas32\__init__.py' -Encoding utf8"
-    powershell -Command "(Get-Content 'scipy_openblas32\__init__.py') -replace 'cflags =.*', 'cflags = \"-DBLAS_SYMBOL_PREFIX=scipy_\"' | Out-File 'local\scipy_openblas32\__init__.py' -Encoding utf8"
+    powershell -Command "(Get-Content 'scipy_openblas32\__init__.py') -replace 'cflags =.*', 'cflags = \"-DBLAS_SYMBOL_PREFIX=scipy_\"' | Out-File 'scipy_openblas32\__init__.py' -Encoding utf8"
     cd ..
 )
 


### PR DESCRIPTION
- [x] I updated the package version in pyproject.toml and made sure the first 3 numbers match  `./openblas_commit.txt`. If I did not update `./openblas_commit.txt`, I incremented the wheel build number (i.e. 0.3.29.0.0 to 0.3.29.0.1)

Note: update `./openblas_commit.txt` with `cd OpenBLAS; git describe --tags --abbrev=8 > ../openblas_commit.txt`

I had a typo. It is a shame there is no general "exit on error" from a batch file. The error appeared but it was hidden in the logs. I could append `|| goto :error` to each line of the batch file, but that is painful. I would prefer to move to bash, see #248.