### PR TITLE
fix condition to allow upload to anaconda.org

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -124,7 +124,8 @@ jobs:
         path: dist/scipy_openblas*.whl
 
     - name: Upload to ananconda.org
-      if: ${{ inputs.publish == false && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+      if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' ||
+  (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
       uses: scientific-python/upload-nightly-action@0.6.4
       with:
         artifacts_path: dist

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -124,8 +124,7 @@ jobs:
         path: dist/scipy_openblas*.whl
 
     - name: Upload to ananconda.org
-      if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' ||
-  (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+      if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
       uses: scientific-python/upload-nightly-action@0.6.4
       with:
         artifacts_path: dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## OpenBLAS v0.3.33
 
+### 0.3.33.0.1 (2026-05-04)
+- Fix posix uploads to anaconda.org
+
 ### 0.3.33.0.0 (2026-05-03)
 - Update to OpenBLAS 0.3.33
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "scipy-openblas64"
 # v0.3.33
-version = "0.3.33.0.0"
+version = "0.3.33.0.1"
 requires-python = ">=3.7"
 description = "Provides OpenBLAS for python packaging"
 readme = "README.md"


### PR DESCRIPTION
- [x] I updated the package version in pyproject.toml and made sure the first 3 numbers match  `./openblas_commit.txt`. If I did not update `./openblas_commit.txt`, I incremented the wheel build number (i.e. 0.3.29.0.0 to 0.3.29.0.1)

Note: update `./openblas_commit.txt` with `cd OpenBLAS; git describe --tags --abbrev=8 > ../openblas_commit.txt`


The condition on upload was wrong.